### PR TITLE
fix: coordinate-dependent block collision bypass

### DIFF
--- a/src/physics/engines/botcraft.ts
+++ b/src/physics/engines/botcraft.ts
@@ -27,6 +27,8 @@ type CheapEnchantmentNames = keyof ReturnType<typeof getEnchantmentNamesForVersi
 type Heading = { forward: number; strafe: number };
 type World = { getBlock: world.WorldSync["getBlock"]};
 
+const COLLISION_EPSILON = 1e-7;
+
 
 function extractAttribute(ctx: IPhysics, genericName: string) {
   const data = ctx.data.attributesByName[genericName] as any;
@@ -1559,7 +1561,7 @@ export class BotcraftPhysics implements IPhysics {
   }
 
   shapeCollide(axis: number, bb: AABB, colliders: AABB[], movement: number): number {
-    if (Math.abs(movement) < 1e-7) {
+    if (Math.abs(movement) < COLLISION_EPSILON) {
       return 0.0;
     }
 
@@ -1587,69 +1589,52 @@ export class BotcraftPhysics implements IPhysics {
    * @returns The adjusted movement amount that prevents collisions
    */
   private voxelShapeCollide(axis: number, bb: AABB, movement: number, colliders: AABB[]): number {
-    // If there's no movement or no colliders, return the original movement
-    if (movement === 0 || colliders.length === 0) {
+    if (Math.abs(movement) < COLLISION_EPSILON) {
+      return 0;
+    }
+    if (colliders.length === 0) {
       return movement;
     }
 
     let adjustedMovement = movement;
+    const axis1 = (axis + 1) % 3;
+    const axis2 = (axis + 2) % 3;
+
+    const getMin = (aabb: AABB, ax: number) => {
+      if (ax === 0) return aabb.minX;
+      if (ax === 1) return aabb.minY;
+      return aabb.minZ;
+    };
+    const getMax = (aabb: AABB, ax: number) => {
+      if (ax === 0) return aabb.maxX;
+      if (ax === 1) return aabb.maxY;
+      return aabb.maxZ;
+    };
 
     for (const collider of colliders) {
-      // Calculate offset manually based on the axis
-      if (axis === 0) { // X axis
-        // Check if there's overlap in Y and Z axes
-        if (bb.maxY > collider.minY && bb.minY < collider.maxY &&
-          bb.maxZ > collider.minZ && bb.minZ < collider.maxZ) {
+      const overlapsAxis1 =
+        getMax(bb, axis1) - COLLISION_EPSILON > getMin(collider, axis1) &&
+        getMin(bb, axis1) + COLLISION_EPSILON < getMax(collider, axis1);
+      const overlapsAxis2 =
+        getMax(bb, axis2) - COLLISION_EPSILON > getMin(collider, axis2) &&
+        getMin(bb, axis2) + COLLISION_EPSILON < getMax(collider, axis2);
 
-          if (movement > 0 && bb.maxX + movement > collider.minX && bb.maxX <= collider.minX) {
-            // Moving right and will collide
-            adjustedMovement = Math.min(adjustedMovement, collider.minX - bb.maxX);
-          }
-          else if (movement < 0 && bb.minX + movement < collider.maxX && bb.minX >= collider.maxX) {
-            // Moving left and will collide
-            adjustedMovement = Math.max(adjustedMovement, collider.maxX - bb.minX);
-          }
-        }
+      if (!overlapsAxis1 || !overlapsAxis2) {
+        continue;
       }
-      else if (axis === 1) { // Y axis
-        // Check if there's overlap in X and Z axes
-        if (bb.maxX > collider.minX && bb.minX < collider.maxX &&
-          bb.maxZ > collider.minZ && bb.minZ < collider.maxZ) {
 
-          if (movement > 0 && bb.maxY + movement > collider.minY && bb.maxY <= collider.minY) {
-            // Moving up and will collide
-            adjustedMovement = Math.min(adjustedMovement, collider.minY - bb.maxY);
-          }
-          else if (movement < 0 && bb.minY + movement < collider.maxY && bb.minY >= collider.maxY) {
-            // Moving down and will collide
-            adjustedMovement = Math.max(adjustedMovement, collider.maxY - bb.minY);
-          }
+      if (movement > 0) {
+        const gap = getMin(collider, axis) - getMax(bb, axis);
+        if (gap >= -COLLISION_EPSILON) {
+          adjustedMovement = Math.min(adjustedMovement, gap);
         }
-      }
-      else { // Z axis
-        // Check if there's overlap in X and Y axes
-        if (bb.maxX > collider.minX && bb.minX < collider.maxX &&
-          bb.maxY > collider.minY && bb.minY < collider.maxY) {
-
-          if (movement > 0 && bb.maxZ + movement > collider.minZ && bb.maxZ <= collider.minZ) {
-            // Moving forward and will collide
-            adjustedMovement = Math.min(adjustedMovement, collider.minZ - bb.maxZ);
-          }
-          else if (movement < 0 && bb.minZ + movement < collider.maxZ && bb.minZ >= collider.maxZ) {
-            // Moving backward and will collide
-            adjustedMovement = Math.max(adjustedMovement, collider.maxZ - bb.minZ);
-          }
+      } else {
+        const gap = getMax(collider, axis) - getMin(bb, axis);
+        if (gap <= COLLISION_EPSILON) {
+          adjustedMovement = Math.max(adjustedMovement, gap);
         }
       }
     }
-
-    // if (axis === 0) {
-    //   ('test')
-    //   console.log(bb, colliders,)
-    //   console.log('movement:', movement, 'adjustedMovement', adjustedMovement)
-    //   console.log('end test')
-    //   console.log
-    // }
 
     return adjustedMovement;
   }

--- a/tests/unit/world/collision.test.ts
+++ b/tests/unit/world/collision.test.ts
@@ -6,6 +6,23 @@ import { createBotcraftPlayerRig, createFlatWorld, loadMcData } from "../../help
 
 const version = "1.12.2";
 const groundLevel = 67;
+const CONTACT_EPSILON = 1e-7;
+const PLAYER_HALF_WIDTH = 0.3;
+
+function simulateTicks(
+  rig: ReturnType<typeof createBotcraftPlayerRig>,
+  fakeWorld: ReturnType<typeof createFlatWorld>,
+  ticks: number,
+) {
+  for (let i = 0; i < ticks; i++) {
+    rig.physics.simulate(rig.playerCtx, fakeWorld);
+    rig.playerState.apply(rig.fakePlayer);
+  }
+}
+
+function assertContactPosition(actual: number, expected: number) {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(CONTACT_EPSILON);
+}
 
 describe("World collision simulation", () => {
   const { mcData } = loadMcData(version);
@@ -27,7 +44,7 @@ describe("World collision simulation", () => {
     rig.playerState.control.forward = true;
 
     for (let i = 0; i < 10; i++) {
-      rig.physics.simulate(rig.playerCtx, fakeWorld as any);
+      rig.physics.simulate(rig.playerCtx, fakeWorld);
       rig.playerState.apply(rig.fakePlayer);
     }
 
@@ -47,7 +64,7 @@ describe("World collision simulation", () => {
     rig.playerState.control.forward = true;
 
     for (let i = 0; i < 10; i++) {
-      rig.physics.simulate(rig.playerCtx, fakeWorld as any);
+      rig.physics.simulate(rig.playerCtx, fakeWorld);
       rig.playerState.apply(rig.fakePlayer);
     }
 
@@ -67,7 +84,7 @@ describe("World collision simulation", () => {
     rig.playerState.control.forward = true;
 
     for (let i = 0; i < 10; i++) {
-      rig.physics.simulate(rig.playerCtx, fakeWorld as any);
+      rig.physics.simulate(rig.playerCtx, fakeWorld);
       rig.playerState.apply(rig.fakePlayer);
     }
 
@@ -87,7 +104,7 @@ describe("World collision simulation", () => {
     rig.playerState.control.forward = true;
 
     for (let i = 0; i < 10; i++) {
-      rig.physics.simulate(rig.playerCtx, fakeWorld as any);
+      rig.physics.simulate(rig.playerCtx, fakeWorld);
       rig.playerState.apply(rig.fakePlayer);
     }
 
@@ -111,7 +128,7 @@ describe("World collision simulation", () => {
     rig.playerState.control.sprint = true;
 
     for (let i = 0; i < 12; i++) {
-      rig.physics.simulate(rig.playerCtx, fakeWorld as any);
+      rig.physics.simulate(rig.playerCtx, fakeWorld);
       rig.playerState.apply(rig.fakePlayer);
     }
 
@@ -139,10 +156,130 @@ describe("World collision simulation", () => {
     rig.playerState.control.sprint = true;
 
     for (let i = 0; i < 4; i++) {
-      rig.physics.simulate(rig.playerCtx, fakeWorld as any);
+      rig.physics.simulate(rig.playerCtx, fakeWorld);
       rig.playerState.apply(rig.fakePlayer);
     }
 
     expect(rig.playerState.pos.y).toEqual(groundLevel + 1);
+  });
+
+  it("does not pass through a block at coordinate boundary z=32 when moving toward negative z", () => {
+    const rig = createBotcraftPlayerRig({
+      version,
+      position: new Vec3(0.5, groundLevel, 32.51),
+      groundLevel,
+    });
+
+    fakeWorld.setOverrideBlock(new Vec3(0, groundLevel, 31), mcData.blocksByName.dirt.id);
+    rig.fakePlayer.entity.position = new Vec3(0.5, groundLevel, 32.51);
+    rig.playerState.pos = rig.fakePlayer.entity.position.clone();
+    rig.playerState.look(0, 0);
+    rig.playerState.control.forward = true;
+
+    simulateTicks(rig, fakeWorld, 12);
+
+    const expectedContactZ = 32 + PLAYER_HALF_WIDTH;
+    assertContactPosition(rig.playerState.pos.z, expectedContactZ);
+    expect(rig.playerState.pos.z).toBeGreaterThan(32);
+    expect(rig.playerState.isCollidedHorizontally).toEqual(true);
+  });
+
+  const boundaryCases = [
+    { boundary: 2, axis: "z" as const },
+    { boundary: 32, axis: "z" as const },
+    { boundary: -2, axis: "z" as const },
+    { boundary: -32, axis: "z" as const },
+    { boundary: 2, axis: "x" as const },
+    { boundary: 32, axis: "x" as const },
+    { boundary: -2, axis: "x" as const },
+    { boundary: -32, axis: "x" as const },
+  ];
+
+  for (const { boundary, axis } of boundaryCases) {
+    const positiveBoundary = boundary > 0;
+
+    it(`holds contact at boundary ${boundary} on ${axis} when moving toward block from the ${positiveBoundary ? "positive" : "negative"} side`, () => {
+      const rig = createBotcraftPlayerRig({
+        version,
+        position: new Vec3(0.5, groundLevel, 0.5),
+        groundLevel,
+      });
+
+      let playerPos: Vec3;
+      let blockPos: Vec3;
+      let expectedContact: number;
+
+      if (axis === "z") {
+        if (positiveBoundary) {
+          blockPos = new Vec3(0, groundLevel, boundary - 1);
+          playerPos = new Vec3(0.5, groundLevel, boundary + 0.51);
+          expectedContact = boundary + PLAYER_HALF_WIDTH;
+          rig.playerState.look(0, 0);
+        } else {
+          blockPos = new Vec3(0, groundLevel, boundary);
+          playerPos = new Vec3(0.5, groundLevel, boundary - 0.51);
+          expectedContact = boundary - PLAYER_HALF_WIDTH;
+          rig.playerState.look(-359.9999 * (Math.PI / 360), 0);
+        }
+      } else if (positiveBoundary) {
+        blockPos = new Vec3(boundary - 1, groundLevel, 0);
+        playerPos = new Vec3(boundary + 0.51, groundLevel, 0.5);
+        expectedContact = boundary + PLAYER_HALF_WIDTH;
+        rig.playerState.look(180 * (Math.PI / 360), 0);
+      } else {
+        blockPos = new Vec3(boundary, groundLevel, 0);
+        playerPos = new Vec3(boundary - 0.51, groundLevel, 0.5);
+        expectedContact = boundary - PLAYER_HALF_WIDTH;
+        rig.playerState.look(-180 * (Math.PI / 360), 0);
+      }
+
+      fakeWorld.setOverrideBlock(blockPos, mcData.blocksByName.dirt.id);
+      rig.fakePlayer.entity.position = playerPos.clone();
+      rig.playerState.pos = playerPos.clone();
+      rig.playerState.control.forward = true;
+
+      simulateTicks(rig, fakeWorld, 12);
+
+      const actualContact = axis === "z" ? rig.playerState.pos.z : rig.playerState.pos.x;
+      assertContactPosition(actualContact, expectedContact);
+      expect(rig.playerState.isCollidedHorizontally).toEqual(true);
+
+      const beforeSecondPass = actualContact;
+      simulateTicks(rig, fakeWorld, 6);
+      const afterSecondPass = axis === "z" ? rig.playerState.pos.z : rig.playerState.pos.x;
+      assertContactPosition(afterSecondPass, expectedContact);
+      expect(Math.abs(afterSecondPass - beforeSecondPass)).toBeLessThanOrEqual(CONTACT_EPSILON);
+    });
+  }
+
+  it("slides along a wall without penetrating it on coordinate boundary z=32", () => {
+    const rig = createBotcraftPlayerRig({
+      version,
+      position: new Vec3(0.5, groundLevel, 32.51),
+      groundLevel,
+    });
+
+    for (let x = -3; x <= 3; x++) {
+      fakeWorld.setOverrideBlock(new Vec3(x, groundLevel, 31), mcData.blocksByName.dirt.id);
+    }
+    rig.fakePlayer.entity.position = new Vec3(0.5, groundLevel, 32.51);
+    rig.playerState.pos = rig.fakePlayer.entity.position.clone();
+    rig.playerState.look(0, 0);
+    rig.playerState.control.forward = true;
+
+    simulateTicks(rig, fakeWorld, 8);
+
+    const expectedContactZ = 32 + PLAYER_HALF_WIDTH;
+    assertContactPosition(rig.playerState.pos.z, expectedContactZ);
+
+    const settledZ = rig.playerState.pos.z;
+    const startX = rig.playerState.pos.x;
+    rig.playerState.control.left = true;
+
+    simulateTicks(rig, fakeWorld, 8);
+
+    assertContactPosition(rig.playerState.pos.z, settledZ);
+    expect(Math.abs(rig.playerState.pos.x - startX)).toBeGreaterThan(0.01);
+    expect(rig.playerState.isCollidedHorizontally).toEqual(true);
   });
 });


### PR DESCRIPTION
Player block collisions could fail at specific coordinate planes. The first collision tick correctly stopped the player at the block surface, but floating-point drift could place the reconstructed AABB a tiny amount inside the block on the next tick.

For example, with the player's `0.3` half-width:

```text
32.3 - 0.3 = 31.999999999999996
```

The strict `bb.min >= collider.max` check would then fail. Since the solver no longer considered the player to be outside the collider, subsequent movement could pass through the block.

This was initially reported as a chunk-boundary issue, but it is not caused by chunk lookup or loading. For the standard `0.6`-wide player hitbox and integer block boundaries, it reproduces at coordinate planes:

```text
2, 32, 512, 8192, 131072, 2097152, ...
```

These follow `2 × 16ⁿ`, with mirrored negative coordinates depending on the movement direction. Most of them are also divisible by 16, which made the issue appear chunk-related, but it also reproduces at coordinate `2`.

### Changes

- Use vanilla's `1e-7` collision epsilon for AABB movement.
- Treat sub-epsilon penetration caused by floating-point rounding as surface contact.
- Apply epsilon-aware overlap and gap checks consistently across X, Y, and Z.
- Add regression coverage for:
  - coordinate boundaries `±2` and `±32`;
  - both horizontal axes and movement directions;
  - sustained movement into a block;
  - sliding along a wall without entering it.

No coordinate-specific rounding or chunk-boundary workaround is used.

### Verification

Automated:

- `pnpm test -- --grep collision` — 16 passing.
- `pnpm build` — passing.
- `pnpm exec eslint tests/unit/world/collision.test.ts` — passing.
- Full test suite — 33 passing, with one unrelated pre-existing failure:
  `clears sprinting while preserving grounded fall-flying state`.
  The same failure is present on the unchanged upstream baseline.

Manual verification was performed in Minecraft Web Client singleplayer with the local physics package linked.

A convenient reproduction point is `8192, <Y>, 8192`. Build solid walls immediately on the negative X and negative Z sides of these coordinate planes, then approach either wall from the positive side.

Before this fix, the player could cross the corresponding block face after initially touching it. After the fix, the player remains at approximately `8192.3` on the collision axis and can slide along the wall normally without visible jitter.