### PR TITLE
feat(physics): add boat and horse physics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ export { PhysicsUtilWrapper } from "./wrapper";
 
 export { EPhysicsCtx, PhysicsWorldSettings } from "./physics/settings";
 export { BaseSimulator } from "./simulators";
-export { EntityPhysics, BotcraftPhysics } from "./physics/engines";
-export { EntityState, PlayerState, PlayerPoses, IEntityState } from "./physics/states";
+export { EntityPhysics, BotcraftPhysics, BoatPhysics } from "./physics/engines";
+export { EntityState, PlayerState, PlayerPoses, IEntityState, BoatState, BoatStatus } from "./physics/states";
 export { ControlStateHandler } from "./physics/player";
 
 export type { SimulationGoal, Controller, OnGoalReachFunction }from "./simulators";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ export { PhysicsUtilWrapper } from "./wrapper";
 
 export { EPhysicsCtx, PhysicsWorldSettings } from "./physics/settings";
 export { BaseSimulator } from "./simulators";
-export { EntityPhysics, BotcraftPhysics, BoatPhysics } from "./physics/engines";
-export { EntityState, PlayerState, PlayerPoses, IEntityState, BoatState, BoatStatus } from "./physics/states";
+export { EntityPhysics, BotcraftPhysics, BoatPhysics, HorsePhysics } from "./physics/engines";
+export { EntityState, PlayerState, PlayerPoses, IEntityState, BoatState, BoatStatus, HorseState } from "./physics/states";
 export { ControlStateHandler } from "./physics/player";
 
 export type { SimulationGoal, Controller, OnGoalReachFunction }from "./simulators";

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -17,7 +17,6 @@ const FLOWING_WATER_VERTICAL = Math.fround(-0.0007);
 const ROTATION_PER_TICK = Math.PI / 180;
 const DEFAULT_BLOCK_FRICTION = 0.6;
 const MAX_CONTROL_ACCELERATION = Math.fround(0.04);
-const MAX_VERTICAL_MOTION = Math.fround(GRAVITY + BUOYANCY_UNDER_WATER + 0.101);
 
 export class BoatPhysics extends EntityPhysics {
   constructor(mcData: md.IndexedData) {
@@ -52,7 +51,7 @@ export class BoatPhysics extends EntityPhysics {
     return this.getEntityBB(simCtx, state.pos);
   }
 
-  private getWorldQueryBlockRange(simCtx: EPhysicsCtx, state: BoatState): {
+  private getWorldReadinessBlockRange(simCtx: EPhysicsCtx, state: BoatState): {
     minX: number;
     maxX: number;
     minY: number;
@@ -61,33 +60,25 @@ export class BoatPhysics extends EntityPhysics {
     maxZ: number;
   } {
     const bb = this.getBoatBB(simCtx, state);
-    const sweepX = Math.abs(state.vel.x) + MAX_CONTROL_ACCELERATION;
-    const sweepY = Math.max(Math.abs(state.vel.y), Math.abs(state.lastVerticalVelocity), MAX_VERTICAL_MOTION);
-    const sweepZ = Math.abs(state.vel.z) + MAX_CONTROL_ACCELERATION;
-
-    const sweptMinX = bb.minX - sweepX;
-    const sweptMaxX = bb.maxX + sweepX;
-    const sweptMinY = bb.minY - sweepY;
-    const sweptMaxY = bb.maxY + sweepY + 0.001;
-    const sweptMinZ = bb.minZ - sweepZ;
-    const sweptMaxZ = bb.maxZ + sweepZ;
+    const margin = 1;
 
     return {
-      minX: Math.floor(sweptMinX) - 1,
-      maxX: Math.ceil(sweptMaxX) + 1,
-      minY: Math.floor(sweptMinY) - 1,
+      minX: Math.floor(bb.minX) - margin,
+      maxX: Math.ceil(bb.maxX) + margin,
+      minY: Math.floor(bb.minY) - margin,
       maxY: Math.max(
-        Math.ceil(sweptMaxY) + 1,
-        Math.ceil(bb.maxY - state.lastVerticalVelocity) + 1,
-        Math.ceil(bb.maxY) + 1,
+        Math.ceil(bb.maxY) + margin,
+        Math.ceil(bb.maxY - state.lastVerticalVelocity) + margin,
+        Math.ceil(bb.maxY + 0.001) + margin,
+        Math.ceil(bb.minY + 0.001) + margin,
       ),
-      minZ: Math.floor(sweptMinZ) - 1,
-      maxZ: Math.ceil(sweptMaxZ) + 1,
+      minZ: Math.floor(bb.minZ) - margin,
+      maxZ: Math.ceil(bb.maxZ) + margin,
     };
   }
 
   private isWorldReady(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): boolean {
-    const range = this.getWorldQueryBlockRange(simCtx, state);
+    const range = this.getWorldReadinessBlockRange(simCtx, state);
     const cursor = new Vec3(0, 0, 0);
 
     for (cursor.y = range.minY; cursor.y <= range.maxY; cursor.y++) {
@@ -296,12 +287,18 @@ export class BoatPhysics extends EntityPhysics {
       state.status !== BoatStatus.ON_LAND
     ) {
       const bb = this.getBoatBB(simCtx, state);
+      state.waterLevel = bb.maxY;
       const waterLevelAbove = this.getWaterLevelAbove(bb, state.lastVerticalVelocity, world);
       const targetY = waterLevelAbove - state.height + 0.101;
       const dy = targetY - state.pos.y;
-      this.moveEntity(simCtx, 0, dy, 0, world);
-      state.vel.y = 0;
-      state.lastVerticalVelocity = 0;
+      const targetPos = { x: state.pos.x, y: state.pos.y + dy, z: state.pos.z };
+      const targetBB = this.getEntityBB(simCtx, targetPos);
+      const hasSolidCollision = this.getSurroundingBBs(targetBB, world).some((bb) => targetBB.intersects(bb));
+      if (dy !== 0 && !hasSolidCollision) {
+        this.moveEntity(simCtx, 0, dy, 0, world);
+        state.vel.y = 0;
+        state.lastVerticalVelocity = 0;
+      }
       state.status = BoatStatus.IN_WATER;
       return;
     }
@@ -324,6 +321,9 @@ export class BoatPhysics extends EntityPhysics {
         break;
       case BoatStatus.ON_LAND:
         invFriction = state.landFriction;
+        if (state.controllingPlayer) {
+          state.landFriction /= 2;
+        }
         break;
     }
 

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -81,7 +81,7 @@ export class BoatPhysics extends EntityPhysics {
     const range = this.getWorldReadinessBlockRange(simCtx, state);
     const cursor = new Vec3(0, 0, 0);
 
-    for (cursor.y = range.minY; cursor.y <= range.maxY; cursor.y++) {
+    for (cursor.y = range.minY; cursor.y < range.maxY; cursor.y++) {
       for (cursor.z = range.minZ; cursor.z < range.maxZ; cursor.z++) {
         for (cursor.x = range.minX; cursor.x < range.maxX; cursor.x++) {
           if (world.getBlock(cursor) == null) {
@@ -354,7 +354,7 @@ export class BoatPhysics extends EntityPhysics {
     state.yaw += state.yawVelocity;
 
     if (control.forward) {
-      acceleration += Math.fround(0.04);
+      acceleration += MAX_CONTROL_ACCELERATION;
     }
     if (control.back) {
       acceleration -= Math.fround(0.005);

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -1,0 +1,376 @@
+import { AABB } from "@nxg-org/mineflayer-util-plugin";
+import md from "minecraft-data";
+import { Block } from "prismarine-block";
+import { Vec3 } from "vec3";
+import { EPhysicsCtx } from "../settings/entityPhysicsCtx";
+import { BoatState, BoatStatus } from "../states/boatState";
+import { IEntityState } from "../states";
+import { EntityPhysics } from "./entityPhysics";
+
+type PhysicsWorld = {
+  getBlock(pos: Vec3): Block | null | undefined;
+};
+
+const GRAVITY = Math.fround(0.04);
+const BUOYANCY_UNDER_WATER = Math.fround(0.01);
+const FLOWING_WATER_VERTICAL = Math.fround(-0.0007);
+const ROTATION_PER_TICK = Math.PI / 180;
+const DEFAULT_BLOCK_FRICTION = 0.6;
+const MAX_CONTROL_ACCELERATION = Math.fround(0.04);
+const MAX_VERTICAL_MOTION = Math.fround(GRAVITY + BUOYANCY_UNDER_WATER + 0.101);
+
+export class BoatPhysics extends EntityPhysics {
+  constructor(mcData: md.IndexedData) {
+    super(mcData);
+  }
+
+  simulate(simCtx: EPhysicsCtx, world: PhysicsWorld): IEntityState {
+    if (!(simCtx.state instanceof BoatState)) {
+      return super.simulate(simCtx, world);
+    }
+
+    const state = simCtx.state;
+    if (!this.isWorldReady(simCtx, state, world)) {
+      state.worldReady = false;
+      return state;
+    }
+
+    state.worldReady = true;
+
+    state.previousStatus = state.status;
+    state.status = this.getStatus(simCtx, state, world);
+    this.floatBoat(simCtx, state, world);
+    this.controlBoat(state);
+    state.lastVerticalVelocity = state.vel.y;
+
+    this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
+    state.age++;
+    return state;
+  }
+
+  private getBoatBB(simCtx: EPhysicsCtx, state: BoatState): AABB {
+    return this.getEntityBB(simCtx, state.pos);
+  }
+
+  private getWorldQueryBlockRange(simCtx: EPhysicsCtx, state: BoatState): {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    minZ: number;
+    maxZ: number;
+  } {
+    const bb = this.getBoatBB(simCtx, state);
+    const sweepX = Math.abs(state.vel.x) + MAX_CONTROL_ACCELERATION;
+    const sweepY = Math.max(Math.abs(state.vel.y), Math.abs(state.lastVerticalVelocity), MAX_VERTICAL_MOTION);
+    const sweepZ = Math.abs(state.vel.z) + MAX_CONTROL_ACCELERATION;
+
+    const sweptMinX = bb.minX - sweepX;
+    const sweptMaxX = bb.maxX + sweepX;
+    const sweptMinY = bb.minY - sweepY;
+    const sweptMaxY = bb.maxY + sweepY + 0.001;
+    const sweptMinZ = bb.minZ - sweepZ;
+    const sweptMaxZ = bb.maxZ + sweepZ;
+
+    return {
+      minX: Math.floor(sweptMinX) - 1,
+      maxX: Math.ceil(sweptMaxX) + 1,
+      minY: Math.floor(sweptMinY) - 1,
+      maxY: Math.max(
+        Math.ceil(sweptMaxY) + 1,
+        Math.ceil(bb.maxY - state.lastVerticalVelocity) + 1,
+        Math.ceil(bb.maxY) + 1,
+      ),
+      minZ: Math.floor(sweptMinZ) - 1,
+      maxZ: Math.ceil(sweptMaxZ) + 1,
+    };
+  }
+
+  private isWorldReady(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): boolean {
+    const range = this.getWorldQueryBlockRange(simCtx, state);
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = range.minY; cursor.y <= range.maxY; cursor.y++) {
+      for (cursor.z = range.minZ; cursor.z < range.maxZ; cursor.z++) {
+        for (cursor.x = range.minX; cursor.x < range.maxX; cursor.x++) {
+          if (world.getBlock(cursor) == null) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  private getStatus(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): BoatStatus {
+    const bb = this.getBoatBB(simCtx, state);
+    const underwater = this.isUnderwater(bb, world);
+    if (underwater != null) {
+      state.waterLevel = bb.maxY;
+      return underwater;
+    }
+    if (this.checkInWater(bb, state, world)) {
+      return BoatStatus.IN_WATER;
+    }
+    const groundFriction = this.getGroundFriction(bb, world);
+    if (groundFriction > 0) {
+      state.landFriction = groundFriction;
+      return BoatStatus.ON_LAND;
+    }
+    return BoatStatus.IN_AIR;
+  }
+
+  private isUnderwater(bb: AABB, world: PhysicsWorld): BoatStatus | null {
+    const topY = bb.maxY + 0.001;
+    const minX = Math.floor(bb.minX);
+    const maxX = Math.ceil(bb.maxX);
+    const minY = Math.floor(bb.maxY);
+    const maxY = Math.ceil(topY);
+    const minZ = Math.floor(bb.minZ);
+    const maxZ = Math.ceil(bb.maxZ);
+    let foundSource = false;
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+      for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+        for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+          const block = world.getBlock(cursor);
+          if (!this.isWaterBlock(block)) continue;
+          const fluidHeight = cursor.y + this.getFluidHeight(block, world, cursor);
+          if (topY < fluidHeight) {
+            if (!this.isSourceWater(block)) {
+              return BoatStatus.UNDER_FLOWING_WATER;
+            }
+            foundSource = true;
+          }
+        }
+      }
+    }
+
+    return foundSource ? BoatStatus.UNDER_WATER : null;
+  }
+
+  private checkInWater(bb: AABB, state: BoatState, world: PhysicsWorld): boolean {
+    const minX = Math.floor(bb.minX);
+    const maxX = Math.ceil(bb.maxX);
+    const minY = Math.floor(bb.minY);
+    const maxY = Math.ceil(bb.minY + 0.001);
+    const minZ = Math.floor(bb.minZ);
+    const maxZ = Math.ceil(bb.maxZ);
+    let inWater = false;
+    state.waterLevel = -Infinity;
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+      for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+        for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+          const block = world.getBlock(cursor);
+          if (!this.isWaterBlock(block)) continue;
+          const fluidHeight = cursor.y + this.getFluidHeight(block, world, cursor);
+          state.waterLevel = Math.max(state.waterLevel, fluidHeight);
+          inWater ||= bb.minY < fluidHeight;
+        }
+      }
+    }
+
+    return inWater;
+  }
+
+  private getWaterLevelAbove(bb: AABB, lastVerticalVelocity: number, world: PhysicsWorld): number {
+    const minX = Math.floor(bb.minX);
+    const maxX = Math.ceil(bb.maxX);
+    const minY = Math.floor(bb.maxY);
+    const maxY = Math.ceil(bb.maxY - lastVerticalVelocity);
+    const minZ = Math.floor(bb.minZ);
+    const maxZ = Math.ceil(bb.maxZ);
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+      let maxSliceHeight = 0;
+      for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+        for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+          const block = world.getBlock(cursor);
+          if (!this.isWaterBlock(block)) continue;
+          maxSliceHeight = Math.max(maxSliceHeight, this.getFluidHeight(block, world, cursor));
+          if (maxSliceHeight >= 1) break;
+        }
+        if (maxSliceHeight >= 1) break;
+      }
+
+      if (maxSliceHeight >= 1) continue;
+      if (maxSliceHeight < 1) {
+        return cursor.y + maxSliceHeight;
+      }
+    }
+
+    return maxY + 1;
+  }
+
+  private getGroundFriction(bb: AABB, world: PhysicsWorld): number {
+    const groundBB = new AABB(bb.minX, bb.minY - 0.001, bb.minZ, bb.maxX, bb.minY, bb.maxZ);
+    const minX = Math.floor(groundBB.minX) - 1;
+    const maxX = Math.ceil(groundBB.maxX) + 1;
+    const minY = Math.floor(groundBB.minY) - 1;
+    const maxY = Math.ceil(groundBB.maxY) + 1;
+    const minZ = Math.floor(groundBB.minZ) - 1;
+    const maxZ = Math.ceil(groundBB.maxZ) + 1;
+    let frictionSum = 0;
+    let count = 0;
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+      for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+        const edgeX = cursor.x === minX || cursor.x === maxX - 1;
+        const edgeZ = cursor.z === minZ || cursor.z === maxZ - 1;
+        const edge = (edgeX ? 1 : 0) + (edgeZ ? 1 : 0);
+        if (edge === 2) continue;
+
+        for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+          if (edge <= 0 || (cursor.y !== minY && cursor.y !== maxY - 1)) {
+            const block = world.getBlock(cursor);
+            if (!block || block.boundingBox === "empty") continue;
+            if (block.name === "lily_pad") continue;
+            const shapes = block.shapes;
+            if (!shapes?.length) continue;
+            for (const shape of shapes) {
+              const blockBB = new AABB(shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]);
+              blockBB.translate(cursor.x, cursor.y, cursor.z);
+              if (blockBB.intersects(groundBB)) {
+                frictionSum += this.blockSlipperiness[block.type] ?? DEFAULT_BLOCK_FRICTION;
+                count++;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return count > 0 ? frictionSum / count : 0;
+  }
+
+  private isWaterBlock(block: Block | null | undefined): block is Block {
+    if (!block) return false;
+    return block.type === this.waterId || this.waterLike.has(block.type) || !!block.getProperties().waterlogged;
+  }
+
+  private isSameFluid(block: Block, other: Block | null | undefined): boolean {
+    if (!other) return false;
+    if (block.type === this.waterId) {
+      return other.type === this.waterId || !!other.getProperties().waterlogged || this.waterLike.has(other.type);
+    }
+    if (block.getProperties().waterlogged) {
+      return this.isWaterBlock(other);
+    }
+    if (this.waterLike.has(block.type)) {
+      return block.type === other.type || this.isWaterBlock(other);
+    }
+    return false;
+  }
+
+  private isSourceWater(block: Block): boolean {
+    if (block.getProperties().waterlogged) return true;
+    if (this.waterLike.has(block.type)) return true;
+    if (block.type !== this.waterId) return false;
+    return Number(block.getProperties().level) === 0;
+  }
+
+  private getFluidHeight(block: Block, world: PhysicsWorld, pos: Vec3): number {
+    const above = world.getBlock(pos.offset(0, 1, 0));
+    if (this.isSameFluid(block, above)) {
+      return 1;
+    }
+    if (block.getProperties().waterlogged || this.waterLike.has(block.type) || block.type === this.waterId) {
+      return 1 - this.getLiquidHeightPcent(block);
+    }
+    return 0;
+  }
+
+  private floatBoat(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): void {
+    let gravity = -GRAVITY;
+    let buoyancy = 0;
+    let invFriction = Math.fround(0.05);
+
+    if (
+      state.previousStatus === BoatStatus.IN_AIR &&
+      state.status !== BoatStatus.IN_AIR &&
+      state.status !== BoatStatus.ON_LAND
+    ) {
+      const bb = this.getBoatBB(simCtx, state);
+      const waterLevelAbove = this.getWaterLevelAbove(bb, state.lastVerticalVelocity, world);
+      const targetY = waterLevelAbove - state.height + 0.101;
+      const dy = targetY - state.pos.y;
+      this.moveEntity(simCtx, 0, dy, 0, world);
+      state.vel.y = 0;
+      state.lastVerticalVelocity = 0;
+      state.status = BoatStatus.IN_WATER;
+      return;
+    }
+
+    switch (state.status) {
+      case BoatStatus.IN_WATER:
+        buoyancy = (state.waterLevel - state.pos.y) / state.height;
+        invFriction = Math.fround(0.9);
+        break;
+      case BoatStatus.UNDER_FLOWING_WATER:
+        gravity = FLOWING_WATER_VERTICAL;
+        invFriction = Math.fround(0.9);
+        break;
+      case BoatStatus.UNDER_WATER:
+        buoyancy = BUOYANCY_UNDER_WATER;
+        invFriction = Math.fround(0.45);
+        break;
+      case BoatStatus.IN_AIR:
+        invFriction = Math.fround(0.9);
+        break;
+      case BoatStatus.ON_LAND:
+        invFriction = state.landFriction;
+        break;
+    }
+
+    state.vel.x = Math.fround(state.vel.x * invFriction);
+    state.vel.y = Math.fround(state.vel.y + gravity);
+    state.vel.z = Math.fround(state.vel.z * invFriction);
+    state.yawVelocity = Math.fround(state.yawVelocity * invFriction);
+
+    if (buoyancy > 0) {
+      state.vel.y = Math.fround((state.vel.y + buoyancy * (GRAVITY / 0.65)) * 0.75);
+    }
+  }
+
+  private controlBoat(state: BoatState): void {
+    const control = state.control;
+    let acceleration = 0;
+
+    if (control.left) {
+      state.yawVelocity += ROTATION_PER_TICK;
+    }
+    if (control.right) {
+      state.yawVelocity -= ROTATION_PER_TICK;
+    }
+    if (control.right !== control.left && !control.forward && !control.back) {
+      acceleration += Math.fround(0.005);
+    }
+
+    state.yaw += state.yawVelocity;
+
+    if (control.forward) {
+      acceleration += Math.fround(0.04);
+    }
+    if (control.back) {
+      acceleration -= Math.fround(0.005);
+    }
+
+    if (acceleration !== 0) {
+      state.vel.x = Math.fround(state.vel.x + -Math.sin(state.yaw) * acceleration);
+      state.vel.z = Math.fround(state.vel.z + -Math.cos(state.yaw) * acceleration);
+    }
+  }
+
+  getPaddleState(state: BoatState): { leftPaddle: boolean; rightPaddle: boolean } {
+    const { left, right, forward } = state.control;
+    return {
+      leftPaddle: (right && !left) || forward,
+      rightPaddle: (left && !right) || forward,
+    };
+  }
+}

--- a/src/physics/engines/horsePhysics.ts
+++ b/src/physics/engines/horsePhysics.ts
@@ -1,0 +1,229 @@
+import { AABB } from "@nxg-org/mineflayer-util-plugin";
+import md from "minecraft-data";
+import { Block } from "prismarine-block";
+import { Vec3 } from "vec3";
+import { EPhysicsCtx } from "../settings/entityPhysicsCtx";
+import { HorseState } from "../states/horseState";
+import { IEntityState } from "../states";
+import { EntityPhysics } from "./entityPhysics";
+
+type PhysicsWorld = {
+  getBlock(pos: Vec3): Block | null | undefined;
+};
+
+const GRAVITY = Math.fround(0.08);
+const VERTICAL_DRAG = Math.fround(0.98);
+const AIR_HORIZONTAL_INERTIA = Math.fround(0.91);
+const WATER_SLOWDOWN = Math.fround(0.8);
+const WATER_INPUT_ACCEL = Math.fround(0.02);
+const GROUND_FRICTION_MULTIPLIER = Math.fround(0.91);
+const FRICTION_INFLUENCED_SPEED_FACTOR = Math.fround(0.21600002);
+const DEFAULT_BLOCK_FRICTION = Math.fround(0.6);
+const HONEY_JUMP_FACTOR = Math.fround(0.5);
+const FORWARD_JUMP_IMPULSE = Math.fround(0.4);
+
+export class HorsePhysics extends EntityPhysics {
+  constructor(mcData: md.IndexedData) {
+    super(mcData);
+  }
+
+  simulate(simCtx: EPhysicsCtx, world: PhysicsWorld): IEntityState {
+    if (!(simCtx.state instanceof HorseState)) {
+      return super.simulate(simCtx, world);
+    }
+
+    const state = simCtx.state;
+    if (!this.isWorldReady(simCtx, state, world)) {
+      state.worldReady = false;
+      return state;
+    }
+
+    state.worldReady = true;
+    simCtx.stepHeight = 1.0;
+    simCtx.gravity = GRAVITY;
+    simCtx.airborneInertia = AIR_HORIZONTAL_INERTIA;
+    simCtx.airborneAccel = Math.fround(state.movementSpeed * 0.1);
+    simCtx.waterInertia = WATER_SLOWDOWN;
+    simCtx.liquidAccel = WATER_INPUT_ACCEL;
+    simCtx.useControls = false;
+    simCtx.collisionBehavior = { blockEffects: true, affectedAfterCollision: true };
+
+    this.updateFluidState(simCtx, state, world);
+    this.applyGroundJump(state, world);
+
+    const { strafe, forward } = state.getTravelInput();
+    if (state.isInWater || state.isInLava) {
+      this.travelInFluid(simCtx, state, strafe, forward, world);
+    } else {
+      this.travelInAir(simCtx, state, strafe, forward, world);
+    }
+
+    state.age++;
+    return state;
+  }
+
+  private getHorseBB(simCtx: EPhysicsCtx, state: HorseState): AABB {
+    return this.getEntityBB(simCtx, state.pos);
+  }
+
+  private getWorldReadinessBlockRange(simCtx: EPhysicsCtx, state: HorseState): {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    minZ: number;
+    maxZ: number;
+  } {
+    const bb = this.getHorseBB(simCtx, state);
+    const input = state.getTravelInput();
+    const yaw = Math.PI - state.yaw;
+    const sin = Math.sin(yaw);
+    const cos = Math.cos(yaw);
+    const dx = input.strafe * cos - input.forward * sin;
+    const dz = input.forward * cos + input.strafe * sin;
+    const swept = bb.clone().extend(dx, state.vel.y, dz);
+    const stepBB = bb.clone().extend(dx, 1.0, dz);
+    const margin = 1;
+
+    return {
+      minX: Math.floor(Math.min(bb.minX, swept.minX, stepBB.minX)) - margin,
+      maxX: Math.ceil(Math.max(bb.maxX, swept.maxX, stepBB.maxX)) + margin,
+      minY: Math.floor(Math.min(bb.minY, swept.minY, stepBB.minY)) - margin,
+      maxY: Math.ceil(Math.max(bb.maxY, swept.maxY, stepBB.maxY)) + margin,
+      minZ: Math.floor(Math.min(bb.minZ, swept.minZ, stepBB.minZ)) - margin,
+      maxZ: Math.ceil(Math.max(bb.maxZ, swept.maxZ, stepBB.maxZ)) + margin,
+    };
+  }
+
+  private isWorldReady(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld): boolean {
+    const range = this.getWorldReadinessBlockRange(simCtx, state);
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = range.minY; cursor.y < range.maxY; cursor.y++) {
+      for (cursor.z = range.minZ; cursor.z < range.maxZ; cursor.z++) {
+        for (cursor.x = range.minX; cursor.x < range.maxX; cursor.x++) {
+          if (world.getBlock(cursor) == null) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  private updateFluidState(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld): void {
+    const vel = state.vel;
+    const waterBB = this.getHorseBB(simCtx, state).contract(0.001, state.vel.y < 0 ? 0.401 : 0.001, 0.001);
+    const lavaBB = this.getHorseBB(simCtx, state).contract(0.1, state.vel.y < 0 ? 0.4 : 0, 0.1);
+    state.isInWater = this.isInWaterApplyCurrent(waterBB, vel, world);
+    state.isInLava = this.isMaterialInBB(lavaBB, this.lavaId, world);
+  }
+
+  private getGroundFriction(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld): number {
+    if (!state.onGround) return Math.fround(1.0);
+    const blockPos = state.pos.floored().offset(0, -1, 0);
+    const block = world.getBlock(blockPos);
+    if (!block || block.boundingBox === "empty") return DEFAULT_BLOCK_FRICTION;
+    return Math.fround(this.blockSlipperiness[block.type] ?? DEFAULT_BLOCK_FRICTION);
+  }
+
+  private getBlockJumpFactor(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld): number {
+    const posBlock = world.getBlock(state.pos.floored());
+    const belowBlock = world.getBlock(state.pos.floored().offset(0, -1, 0));
+    const posFactor = this.getBlockJumpFactorForBlock(posBlock);
+    const belowFactor = this.getBlockJumpFactorForBlock(belowBlock);
+    return posFactor === 1.0 ? belowFactor : posFactor;
+  }
+
+  private getBlockJumpFactorForBlock(block: Block | null | undefined): number {
+    if (!block) return 1.0;
+    if (block.type === this.honeyblockId) return HONEY_JUMP_FACTOR;
+    return 1.0;
+  }
+
+  private applyGroundJump(state: HorseState, world: PhysicsWorld): void {
+    if (!state.onGround) return;
+    if (state.jumpPendingScale <= 0 || state.isJumping) return;
+
+    const blockJumpFactor = this.getBlockJumpFactor({} as EPhysicsCtx, state, world);
+    const jumpBoostPower = state.jumpBoost > 0 ? Math.fround(0.1 * state.jumpBoost) : 0;
+    const jumpVelocity = Math.fround(state.jumpStrength * state.jumpPendingScale * blockJumpFactor + jumpBoostPower);
+    state.vel.y = Math.max(jumpVelocity, state.vel.y);
+    state.isJumping = true;
+    state.onGround = false;
+
+    const { forward } = state.getTravelInput();
+    if (forward > 0) {
+      const notchianYaw = Math.PI - state.yaw;
+      const sin = Math.sin(notchianYaw);
+      const cos = Math.cos(notchianYaw);
+      const impulse = Math.fround(FORWARD_JUMP_IMPULSE * state.jumpPendingScale);
+      state.vel.x = Math.fround(state.vel.x - impulse * sin);
+      state.vel.z = Math.fround(state.vel.z + impulse * cos);
+    }
+
+    state.jumpPendingScale = 0;
+  }
+
+  private travelInAir(simCtx: EPhysicsCtx, state: HorseState, strafe: number, forward: number, world: PhysicsWorld): void {
+    const groundFriction = this.getGroundFriction(simCtx, state, world);
+    const horizontalFriction = Math.fround(groundFriction * GROUND_FRICTION_MULTIPLIER);
+    const acceleration = state.onGround
+      ? Math.fround(state.movementSpeed * (FRICTION_INFLUENCED_SPEED_FACTOR / (groundFriction * groundFriction * groundFriction)))
+      : Math.fround(state.movementSpeed * 0.1);
+
+    this.applyHorseHeading(simCtx, strafe, forward, acceleration);
+    this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
+
+    let dy = state.vel.y;
+    dy = Math.fround(dy - GRAVITY);
+    state.vel.x = Math.fround(state.vel.x * horizontalFriction);
+    state.vel.y = Math.fround(dy * VERTICAL_DRAG);
+    state.vel.z = Math.fround(state.vel.z * horizontalFriction);
+
+    if (!state.onGround && state.vel.y <= 0) {
+      state.isJumping = false;
+    }
+    if (state.onGround) {
+      state.isJumping = false;
+      state.clearGroundJumpPending();
+    }
+  }
+
+  private travelInFluid(simCtx: EPhysicsCtx, state: HorseState, strafe: number, forward: number, world: PhysicsWorld): void {
+    const lastY = state.pos.y;
+    this.applyHorseHeading(simCtx, strafe, forward, WATER_INPUT_ACCEL);
+    this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
+
+    let dy = state.vel.y;
+    if (state.isInWater) {
+      dy = Math.fround(dy - GRAVITY);
+      state.vel.x = Math.fround(state.vel.x * WATER_SLOWDOWN);
+      state.vel.y = Math.fround(dy * WATER_SLOWDOWN);
+      state.vel.z = Math.fround(state.vel.z * WATER_SLOWDOWN);
+    } else {
+      dy = Math.fround(dy - GRAVITY / 4);
+      state.vel.x = Math.fround(state.vel.x * 0.5);
+      state.vel.y = Math.fround(dy * 0.5);
+      state.vel.z = Math.fround(state.vel.z * 0.5);
+    }
+
+    if (
+      state.isCollidedHorizontally &&
+      this.doesNotCollide(simCtx, state.pos.offset(state.vel.x, 0.6 - state.pos.y + lastY, state.vel.z), world)
+    ) {
+      state.vel.y = Math.fround(0.3);
+    }
+  }
+
+  private applyHorseHeading(simCtx: EPhysicsCtx, strafe: number, forward: number, acceleration: number): void {
+    const state = simCtx.state as HorseState;
+    const yaw = Math.PI - state.yaw;
+    const sin = Math.sin(yaw);
+    const cos = Math.cos(yaw);
+    const offsetX = Math.fround(strafe * cos - forward * sin);
+    const offsetZ = Math.fround(forward * cos + strafe * sin);
+    state.vel.x = Math.fround(state.vel.x + offsetX * acceleration);
+    state.vel.z = Math.fround(state.vel.z + offsetZ * acceleration);
+  }
+}

--- a/src/physics/engines/index.ts
+++ b/src/physics/engines/index.ts
@@ -1,4 +1,5 @@
 export * from "./entityPhysics"
 export * from "./botcraft"
+export * from "./boatPhysics"
 export * from "./IPhysics"
 

--- a/src/physics/engines/index.ts
+++ b/src/physics/engines/index.ts
@@ -1,5 +1,6 @@
 export * from "./entityPhysics"
 export * from "./botcraft"
 export * from "./boatPhysics"
+export * from "./horsePhysics"
 export * from "./IPhysics"
 

--- a/src/physics/player/playerControls.ts
+++ b/src/physics/player/playerControls.ts
@@ -1,7 +1,7 @@
 import { MathUtils } from "@nxg-org/mineflayer-util-plugin";
 import { Bot, ControlState, ControlStateStatus } from "mineflayer";
 import { Vec3 } from "vec3";
-import { EntityState, PlayerState } from "../states";
+import type { EntityState, PlayerState } from "../states";
 ;
 
 export class ControlStateHandler implements ControlStateStatus {

--- a/src/physics/states/boatState.ts
+++ b/src/physics/states/boatState.ts
@@ -1,0 +1,121 @@
+import type { Entity } from "prismarine-entity";
+import { Vec3 } from "vec3";
+import type { IPhysics } from "../engines";
+import { ControlStateHandler } from "../player/playerControls";
+import { EntityState } from "./entityState";
+
+export enum BoatStatus {
+  IN_WATER,
+  UNDER_WATER,
+  UNDER_FLOWING_WATER,
+  ON_LAND,
+  IN_AIR,
+}
+
+export class BoatState extends EntityState {
+  status: BoatStatus = BoatStatus.IN_AIR;
+  previousStatus: BoatStatus = BoatStatus.IN_AIR;
+
+  waterLevel = -Infinity;
+  landFriction = 0;
+  yawVelocity = 0;
+  lastVerticalVelocity = 0;
+  underwaterTicks = 0;
+
+  worldReady = true;
+
+  constructor(
+    ctx: IPhysics,
+    height: number,
+    halfWidth: number,
+    pos: Vec3,
+    vel: Vec3,
+    onGround: boolean,
+    yaw: number,
+    pitch: number,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+  ) {
+    super(ctx, height, halfWidth, pos, vel, onGround, yaw, pitch, control);
+  }
+
+  public static CREATE_FROM_ENTITY(
+    ctx: IPhysics,
+    entity: Entity,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+  ): BoatState {
+    return new BoatState(
+      ctx,
+      entity.height ?? 0.5625,
+      (entity.width ?? 1.375) / 2,
+      entity.position.clone(),
+      entity.velocity.clone(),
+      entity.onGround ?? false,
+      entity.yaw,
+      entity.pitch,
+      control.clone(),
+    );
+  }
+
+  public updateControls(control: ControlStateHandler): BoatState {
+    this.control = control.clone();
+    return this;
+  }
+
+  public rebaseFromEntity(entity: Entity, options?: { replaceVelocity?: boolean }): BoatState {
+    this.pos.set(entity.position.x, entity.position.y, entity.position.z);
+    if (options?.replaceVelocity !== false) {
+      this.vel.set(entity.velocity.x, entity.velocity.y, entity.velocity.z);
+    }
+    this.yaw = entity.yaw;
+    this.pitch = entity.pitch;
+    this.onGround = entity.onGround ?? false;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    this.isCollidedHorizontally = entityExtras.isCollidedHorizontally ?? false;
+    this.isCollidedVertically = entityExtras.isCollidedVertically ?? false;
+    return this;
+  }
+
+  public applyToEntity(entity: Entity) {
+    entity.position.set(this.pos.x, this.pos.y, this.pos.z);
+    entity.velocity.set(this.vel.x, this.vel.y, this.vel.z);
+    entity.yaw = this.yaw;
+    entity.pitch = this.pitch;
+    entity.onGround = this.onGround;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    entityExtras.isCollidedHorizontally = this.isCollidedHorizontally;
+    entityExtras.isCollidedVertically = this.isCollidedVertically;
+    return this;
+  }
+
+  public clone(): BoatState {
+    const other = new BoatState(
+      this.ctx,
+      this.height,
+      this.halfWidth,
+      this.pos.clone(),
+      this.vel.clone(),
+      this.onGround,
+      this.yaw,
+      this.pitch,
+      this.control.clone(),
+    );
+    other.status = this.status;
+    other.previousStatus = this.previousStatus;
+    other.waterLevel = this.waterLevel;
+    other.landFriction = this.landFriction;
+    other.yawVelocity = this.yawVelocity;
+    other.lastVerticalVelocity = this.lastVerticalVelocity;
+    other.underwaterTicks = this.underwaterTicks;
+    other.worldReady = this.worldReady;
+    other.age = this.age;
+    other.isCollidedHorizontally = this.isCollidedHorizontally;
+    other.isCollidedVertically = this.isCollidedVertically;
+    return other;
+  }
+}

--- a/src/physics/states/boatState.ts
+++ b/src/physics/states/boatState.ts
@@ -21,6 +21,7 @@ export class BoatState extends EntityState {
   yawVelocity = 0;
   lastVerticalVelocity = 0;
   underwaterTicks = 0;
+  controllingPlayer = false;
 
   worldReady = true;
 
@@ -112,6 +113,7 @@ export class BoatState extends EntityState {
     other.yawVelocity = this.yawVelocity;
     other.lastVerticalVelocity = this.lastVerticalVelocity;
     other.underwaterTicks = this.underwaterTicks;
+    other.controllingPlayer = this.controllingPlayer;
     other.worldReady = this.worldReady;
     other.age = this.age;
     other.isCollidedHorizontally = this.isCollidedHorizontally;

--- a/src/physics/states/boatState.ts
+++ b/src/physics/states/boatState.ts
@@ -20,7 +20,6 @@ export class BoatState extends EntityState {
   landFriction = 0;
   yawVelocity = 0;
   lastVerticalVelocity = 0;
-  underwaterTicks = 0;
   controllingPlayer = false;
 
   worldReady = true;
@@ -112,7 +111,6 @@ export class BoatState extends EntityState {
     other.landFriction = this.landFriction;
     other.yawVelocity = this.yawVelocity;
     other.lastVerticalVelocity = this.lastVerticalVelocity;
-    other.underwaterTicks = this.underwaterTicks;
     other.controllingPlayer = this.controllingPlayer;
     other.worldReady = this.worldReady;
     other.age = this.age;

--- a/src/physics/states/entityState.ts
+++ b/src/physics/states/entityState.ts
@@ -5,13 +5,13 @@ import { Vec3 } from "vec3";
 
 
 import { ControlStateHandler } from "../player/playerControls";
-import { PlayerState } from "./playerState";
+import type { PlayerState } from "./playerState";
 import { PlayerPoses } from "./poses";
 
-import { IPhysics } from "../engines";
+import type { IPhysics } from "../engines";
 import nbt from "prismarine-nbt";
 import {Entity} from "prismarine-entity";
-import { IEntityState } from ".";
+import type { IEntityState } from ".";
 
 
 

--- a/src/physics/states/horseState.ts
+++ b/src/physics/states/horseState.ts
@@ -1,0 +1,228 @@
+import type { Entity } from "prismarine-entity";
+import { Vec3 } from "vec3";
+import type { IPhysics } from "../engines";
+import { ControlStateHandler } from "../player/playerControls";
+import { EntityState } from "./entityState";
+import * as attributes from "../info/attributes";
+
+const DEFAULT_MOVEMENT_SPEED = Math.fround(0.225);
+const DEFAULT_JUMP_STRENGTH = Math.fround(0.7);
+const INPUT_SCALE = Math.fround(0.9800000190734863);
+const STRAFE_SCALE = Math.fround(INPUT_SCALE * 0.5);
+const BACKWARD_SCALE = Math.fround(0.25);
+
+type AttributeProp = { value: number; modifiers: Array<{ uuid: string; operation: number; amount: number }> };
+
+export type HorseJumpRelease = {
+  released: boolean;
+  jumpBoost: number;
+};
+
+export class HorseState extends EntityState {
+  movementSpeed = DEFAULT_MOVEMENT_SPEED;
+  jumpStrength = DEFAULT_JUMP_STRENGTH;
+
+  jumpChargeTicks = 0;
+  jumpChargeScale = 0;
+  jumpPendingScale = 0;
+  previousJumpInput = false;
+  isJumping = false;
+  allowStandSliding = false;
+  saddled = false;
+
+  worldReady = true;
+  attributesReady = false;
+
+  riderYaw = 0;
+  riderPitch = 0;
+
+  constructor(
+    ctx: IPhysics,
+    height: number,
+    halfWidth: number,
+    pos: Vec3,
+    vel: Vec3,
+    onGround: boolean,
+    yaw: number,
+    pitch: number,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+  ) {
+    super(ctx, height, halfWidth, pos, vel, onGround, yaw, pitch, control);
+  }
+
+  public static CREATE_FROM_ENTITY(
+    ctx: IPhysics,
+    entity: Entity,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+  ): HorseState {
+    const state = new HorseState(
+      ctx,
+      entity.height ?? 1.6,
+      (entity.width ?? 1.3964844) / 2,
+      entity.position.clone(),
+      entity.velocity.clone(),
+      entity.onGround ?? false,
+      entity.yaw,
+      entity.pitch,
+      control.clone(),
+    );
+    state.updateFromHorseEntity(entity);
+    return state;
+  }
+
+  public static getMovementSpeedFromAttributes(entityAttributes: Entity["attributes"] | undefined): number {
+    const movementSpeedAttr = entityAttributes?.["generic.movement_speed"] as AttributeProp | undefined;
+    if (!movementSpeedAttr) return DEFAULT_MOVEMENT_SPEED;
+    return Math.fround(attributes.getAttributeValue(movementSpeedAttr));
+  }
+
+  public static getJumpStrengthFromAttributes(entityAttributes: Entity["attributes"] | undefined): number {
+    const jumpStrengthAttr = entityAttributes?.["horse.jump_strength"] as AttributeProp | undefined;
+    if (!jumpStrengthAttr) return DEFAULT_JUMP_STRENGTH;
+    return Math.fround(attributes.getAttributeValue(jumpStrengthAttr));
+  }
+
+  public static getSaddledFromMetadata(entity: Entity): boolean {
+    const flags = entity.metadata?.[17];
+    if (typeof flags !== "number") return false;
+    return (flags & 0x04) !== 0;
+  }
+
+  public updateFromHorseEntity(entity: Entity): HorseState {
+    if (entity.attributes) {
+      this.movementSpeed = HorseState.getMovementSpeedFromAttributes(entity.attributes);
+      this.jumpStrength = HorseState.getJumpStrengthFromAttributes(entity.attributes);
+      this.attributesReady = true;
+    }
+    this.saddled = HorseState.getSaddledFromMetadata(entity);
+    return this;
+  }
+
+  public updateControls(control: ControlStateHandler, riderYaw: number, riderPitch: number): HorseState {
+    this.control = control.clone();
+    this.riderYaw = riderYaw;
+    this.riderPitch = riderPitch;
+    this.yaw = riderYaw;
+    this.pitch = Math.fround(riderPitch * 0.5);
+    return this;
+  }
+
+  public updateJumpCharge(jumpInput: boolean): HorseJumpRelease {
+    const result: HorseJumpRelease = { released: false, jumpBoost: 0 };
+
+    if (!jumpInput && this.previousJumpInput) {
+      this.jumpPendingScale = this.computePendingJumpScale(this.jumpChargeScale);
+      result.released = true;
+      result.jumpBoost = Math.floor(this.jumpChargeScale * 100);
+      this.jumpChargeTicks = -10;
+    } else if (jumpInput && !this.previousJumpInput) {
+      this.jumpChargeTicks = 0;
+      this.jumpChargeScale = 0;
+    } else if (jumpInput) {
+      this.jumpChargeTicks++;
+      this.jumpChargeScale = this.computeChargeScale(this.jumpChargeTicks);
+    } else {
+      this.jumpChargeScale = 0;
+    }
+
+    this.previousJumpInput = jumpInput;
+    return result;
+  }
+
+  private computeChargeScale(ticks: number): number {
+    if (ticks < 10) {
+      return Math.fround(ticks * 0.1);
+    }
+    return Math.fround(0.8 + (2.0 / (ticks - 9)) * 0.1);
+  }
+
+  private computePendingJumpScale(chargeScale: number): number {
+    const jumpBoost = Math.floor(chargeScale * 100);
+    if (jumpBoost >= 90) {
+      return Math.fround(1.0);
+    }
+    return Math.fround(0.4 + 0.4 * (jumpBoost / 90));
+  }
+
+  public getTravelInput(): { strafe: number; forward: number } {
+    const control = this.control;
+    const strafe = Math.fround(((control.left ? 1 : 0) - (control.right ? 1 : 0)) * STRAFE_SCALE);
+    let forward = Math.fround(((control.forward ? 1 : 0) - (control.back ? 1 : 0)) * INPUT_SCALE);
+    if (forward <= 0) {
+      forward = Math.fround(forward * BACKWARD_SCALE);
+    }
+    return { strafe, forward };
+  }
+
+  public clearGroundJumpPending(): void {
+    this.jumpPendingScale = 0;
+  }
+
+  public rebaseFromEntity(entity: Entity, options?: { replaceVelocity?: boolean }): HorseState {
+    this.pos.set(entity.position.x, entity.position.y, entity.position.z);
+    if (options?.replaceVelocity !== false) {
+      this.vel.set(entity.velocity.x, entity.velocity.y, entity.velocity.z);
+    }
+    this.yaw = entity.yaw;
+    this.pitch = entity.pitch;
+    this.onGround = entity.onGround ?? false;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    this.isCollidedHorizontally = entityExtras.isCollidedHorizontally ?? false;
+    this.isCollidedVertically = entityExtras.isCollidedVertically ?? false;
+    this.updateFromHorseEntity(entity);
+    return this;
+  }
+
+  public applyToEntity(entity: Entity) {
+    entity.position.set(this.pos.x, this.pos.y, this.pos.z);
+    entity.velocity.set(this.vel.x, this.vel.y, this.vel.z);
+    entity.yaw = this.yaw;
+    entity.pitch = this.pitch;
+    entity.onGround = this.onGround;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    entityExtras.isCollidedHorizontally = this.isCollidedHorizontally;
+    entityExtras.isCollidedVertically = this.isCollidedVertically;
+    return this;
+  }
+
+  public clone(): HorseState {
+    const other = new HorseState(
+      this.ctx,
+      this.height,
+      this.halfWidth,
+      this.pos.clone(),
+      this.vel.clone(),
+      this.onGround,
+      this.yaw,
+      this.pitch,
+      this.control.clone(),
+    );
+    other.movementSpeed = this.movementSpeed;
+    other.jumpStrength = this.jumpStrength;
+    other.jumpChargeTicks = this.jumpChargeTicks;
+    other.jumpChargeScale = this.jumpChargeScale;
+    other.jumpPendingScale = this.jumpPendingScale;
+    other.previousJumpInput = this.previousJumpInput;
+    other.isJumping = this.isJumping;
+    other.allowStandSliding = this.allowStandSliding;
+    other.saddled = this.saddled;
+    other.worldReady = this.worldReady;
+    other.attributesReady = this.attributesReady;
+    other.riderYaw = this.riderYaw;
+    other.riderPitch = this.riderPitch;
+    other.age = this.age;
+    other.isCollidedHorizontally = this.isCollidedHorizontally;
+    other.isCollidedVertically = this.isCollidedVertically;
+    other.isInWater = this.isInWater;
+    other.isInLava = this.isInLava;
+    other.supportingBlockPos = this.supportingBlockPos?.clone() ?? null;
+    other.jumpBoost = this.jumpBoost;
+    return other;
+  }
+}

--- a/src/physics/states/index.ts
+++ b/src/physics/states/index.ts
@@ -8,6 +8,7 @@ export * from "./entityState"
 export * from "./playerState"
 export * from "./poses"
 export * from "./boatState"
+export * from "./horseState"
 
 export type Heading = {
     forward: number;
@@ -58,9 +59,4 @@ export interface IEntityState {
     clone(): IEntityState;
 
     getBB(): AABB;
-}
-
-export function getPose(entity: Entity) {
-    const pose = entity.metadata.find((e) => (e as any)?.type === 18);
-    return pose ? ((pose as any).value as number) : PlayerPoses.STANDING;
 }

--- a/src/physics/states/index.ts
+++ b/src/physics/states/index.ts
@@ -7,6 +7,7 @@ import { AABB } from "@nxg-org/mineflayer-util-plugin";
 export * from "./entityState"
 export * from "./playerState"
 export * from "./poses"
+export * from "./boatState"
 
 export type Heading = {
     forward: number;

--- a/src/physics/states/playerState.ts
+++ b/src/physics/states/playerState.ts
@@ -15,11 +15,11 @@ import {
 // import { bot.entity } from "prismarine-entity";
 import md from "minecraft-data";
 import { ControlStateHandler } from "../player/playerControls";
-import { IEntityState } from ".";
-import { IPhysics } from "../engines/IPhysics";
+import type { IEntityState } from ".";
+import type { IPhysics } from "../engines/IPhysics";
 import type { Entity } from "prismarine-entity";
-import { PlayerPoses, getCollider, playerPoseCtx } from "./poses";
-import { Heading, getPose } from ".";
+import { PlayerPoses, getCollider, getPose, playerPoseCtx } from "./poses";
+import type { Heading } from ".";
 
 
 export function convInpToAxes(player: PlayerState): Heading {

--- a/src/physics/states/poses.ts
+++ b/src/physics/states/poses.ts
@@ -1,4 +1,5 @@
 import { AABB } from "@nxg-org/mineflayer-util-plugin";
+import type { Entity } from "prismarine-entity";
 import { Vec3 } from "vec3";
 
 //0: STANDING, 1: FALL_FLYING, 2: SLEEPING, 3: SWIMMING, 4: SPIN_ATTACK, 5: SNEAKING, 6: LONG_JUMPING, 7: DYING
@@ -11,6 +12,11 @@ export enum PlayerPoses {
   SNEAKING,
   LONG_JUMPING,
   DYING,
+}
+
+export function getPose(entity: Entity) {
+  const pose = entity.metadata.find((entry) => (entry as any)?.type === 18);
+  return pose ? ((pose as any).value as number) : PlayerPoses.STANDING;
 }
 
 /**

--- a/src/util/physicsUtils.ts
+++ b/src/util/physicsUtils.ts
@@ -3,9 +3,10 @@ import { EPhysicsCtx } from "../physics/settings";
 import { AABB } from "@nxg-org/mineflayer-util-plugin";
 import features from "../physics/info/features.json";
 import md from "minecraft-data";
-import { ControlStateHandler, EntityState, IEntityState, PlayerState } from "../physics/states";
+import { ControlStateHandler } from "../physics/player/playerControls";
+import { PlayerState } from "../physics/states/playerState";
 import { Vec3 } from "vec3";
-import { IPhysics } from "../physics/engines";
+import type { IPhysics } from "../physics/engines";
 import { Bot } from "mineflayer";
 
 export function makeSupportFeature(mcData: md.IndexedData) {

--- a/tests/helpers/unit/botcraftTestSupport.ts
+++ b/tests/helpers/unit/botcraftTestSupport.ts
@@ -3,11 +3,12 @@ import md from "minecraft-data";
 import block, { Block as PBlock } from "prismarine-block";
 import { Vec3 } from "vec3";
 import { initSetup } from "../../../src";
-import { BotcraftPhysics } from "../../../src/physics/engines";
+import { BotcraftPhysics, BoatPhysics } from "../../../src/physics/engines";
 import { ControlStateHandler } from "../../../src/physics/player";
 import { EPhysicsCtx } from "../../../src/physics/settings";
-import { PlayerState } from "../../../src/physics/states";
+import { BoatState, PlayerState } from "../../../src/physics/states";
 import { applyMdToNewEntity } from "../../../src/util/physicsUtils";
+import type { Entity } from "prismarine-entity";
 
 const initializedVersions = new Set<string>();
 
@@ -133,4 +134,106 @@ export function createBotcraftPlayerRig(options: {
     playerCtx,
     playerState,
   };
+}
+
+export class BoatTestWorld {
+  private readonly overrideBlocks: Record<string, PBlock> = {};
+
+  constructor(
+    private readonly blocksByName: ReturnType<typeof md>["blocksByName"],
+    private readonly Block: typeof PBlock,
+    private readonly floorY: number,
+  ) {}
+
+  setBlock(pos: Vec3, type: number, metadata = 0) {
+    const blockPos = pos.floored();
+    const blockInstance = new this.Block(type, 0, metadata);
+    blockInstance.position = blockPos;
+    this.overrideBlocks[this.keyFor(blockPos)] = blockInstance;
+  }
+
+  setWater(pos: Vec3, metadata = 0) {
+    this.setBlock(pos, this.blocksByName.water.id, metadata);
+  }
+
+  setStone(pos: Vec3) {
+    this.setBlock(pos, this.blocksByName.stone.id, 0);
+  }
+
+  setIce(pos: Vec3) {
+    this.setBlock(pos, this.blocksByName.ice.id, 0);
+  }
+
+  clearOverrides() {
+    for (const key of Object.keys(this.overrideBlocks)) {
+      delete this.overrideBlocks[key];
+    }
+  }
+
+  getBlock(pos: Vec3): PBlock | null {
+    const blockPos = pos.floored();
+    const override = this.overrideBlocks[this.keyFor(blockPos)];
+    if (override) {
+      return override;
+    }
+
+    const type = blockPos.y < this.floorY ? this.blocksByName.stone.id : this.blocksByName.air.id;
+    const blockInstance = new this.Block(type, 0, 0);
+    blockInstance.position = blockPos;
+    return blockInstance;
+  }
+
+  private keyFor(pos: Vec3) {
+    return `${pos.x},${pos.y},${pos.z}`;
+  }
+}
+
+export function createBoatTestWorld(version: string, floorY: number) {
+  const { mcData, Block } = loadMcData(version);
+  return new BoatTestWorld(mcData.blocksByName, Block, floorY);
+}
+
+export function createBoatRig(options: {
+  version: string;
+  position: Vec3;
+  floorY?: number;
+}) {
+  const { version, position } = options;
+  const floorY = options.floorY ?? Math.floor(position.y) - 1;
+  const { mcData } = loadMcData(version);
+
+  const physics = new BoatPhysics(mcData);
+  const boatEntityType = mcData.entitiesByName.boat;
+  const boatState = BoatState.CREATE_FROM_ENTITY(physics, {
+    position: position.clone(),
+    velocity: new Vec3(0, 0, 0),
+    yaw: 0,
+    pitch: 0,
+    height: 0.5625,
+    width: 1.375,
+    onGround: false,
+    name: "boat",
+  } as Entity);
+  boatState.control = ControlStateHandler.DEFAULT();
+
+  const boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(physics, boatState, boatEntityType);
+  const world = createBoatTestWorld(version, floorY);
+
+  return {
+    mcData,
+    physics,
+    boatState,
+    boatCtx,
+    world,
+  };
+}
+
+export function simulateBoatTick(rig: ReturnType<typeof createBoatRig>) {
+  rig.physics.simulate(rig.boatCtx, rig.world);
+}
+
+export function fillWaterColumn(world: BoatTestWorld, x: number, z: number, fromY: number, toY: number, metadata = 0) {
+  for (let y = fromY; y <= toY; y++) {
+    world.setWater(new Vec3(x, y, z), metadata);
+  }
 }

--- a/tests/helpers/unit/botcraftTestSupport.ts
+++ b/tests/helpers/unit/botcraftTestSupport.ts
@@ -3,10 +3,10 @@ import md from "minecraft-data";
 import block, { Block as PBlock } from "prismarine-block";
 import { Vec3 } from "vec3";
 import { initSetup } from "../../../src";
-import { BotcraftPhysics, BoatPhysics } from "../../../src/physics/engines";
+import { BotcraftPhysics, BoatPhysics, HorsePhysics } from "../../../src/physics/engines";
 import { ControlStateHandler } from "../../../src/physics/player";
 import { EPhysicsCtx } from "../../../src/physics/settings";
-import { BoatState, PlayerState } from "../../../src/physics/states";
+import { BoatState, HorseState, PlayerState } from "../../../src/physics/states";
 import { applyMdToNewEntity } from "../../../src/util/physicsUtils";
 import type { Entity } from "prismarine-entity";
 
@@ -177,7 +177,7 @@ export class BoatTestWorld {
       return override;
     }
 
-    const type = blockPos.y < this.floorY ? this.blocksByName.stone.id : this.blocksByName.air.id;
+    const type = blockPos.y <= this.floorY ? this.blocksByName.stone.id : this.blocksByName.air.id;
     const blockInstance = new this.Block(type, 0, 0);
     blockInstance.position = blockPos;
     return blockInstance;
@@ -213,7 +213,7 @@ export function createBoatRig(options: {
     width: 1.375,
     onGround: false,
     name: "boat",
-  } as Entity);
+  } as unknown as Entity);
   boatState.control = ControlStateHandler.DEFAULT();
 
   const boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(physics, boatState, boatEntityType);
@@ -230,6 +230,50 @@ export function createBoatRig(options: {
 
 export function simulateBoatTick(rig: ReturnType<typeof createBoatRig>) {
   rig.physics.simulate(rig.boatCtx, rig.world);
+}
+
+export function createHorseRig(options: {
+  version: string;
+  position: Vec3;
+  floorY?: number;
+  attributes?: Record<string, { value: number; modifiers: Array<{ uuid: string; operation: number; amount: number }> }>;
+}) {
+  const { version, position } = options;
+  const floorY = options.floorY ?? Math.floor(position.y) - 1;
+  const { mcData } = loadMcData(version);
+
+  const physics = new HorsePhysics(mcData);
+  const horseEntityType = mcData.entitiesByName.horse;
+  const horseState = HorseState.CREATE_FROM_ENTITY(physics, {
+    position: position.clone(),
+    velocity: new Vec3(0, 0, 0),
+    yaw: 0,
+    pitch: 0,
+    height: 1.6,
+    width: 1.3964844,
+    onGround: true,
+    name: "horse",
+    attributes: options.attributes,
+    metadata: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x04],
+  } as unknown as Entity);
+  horseState.control = ControlStateHandler.DEFAULT();
+  horseState.saddled = true;
+
+  const horseCtx = EPhysicsCtx.FROM_ENTITY_STATE(physics, horseState, horseEntityType);
+  horseCtx.stepHeight = 1.0;
+  const world = createBoatTestWorld(version, floorY);
+
+  return {
+    mcData,
+    physics,
+    horseState,
+    horseCtx,
+    world,
+  };
+}
+
+export function simulateHorseTick(rig: ReturnType<typeof createHorseRig>) {
+  rig.physics.simulate(rig.horseCtx, rig.world);
 }
 
 export function fillWaterColumn(world: BoatTestWorld, x: number, z: number, fromY: number, toY: number, metadata = 0) {

--- a/tests/run.cjs
+++ b/tests/run.cjs
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs')
+const path = require('path')
+const Mocha = require('mocha')
+
+const mocha = new Mocha()
+
+function addTests (directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      addTests(file)
+    } else if (entry.name.endsWith('.test.ts')) {
+      mocha.addFile(file)
+    }
+  }
+}
+
+const testDirectories = process.argv.slice(2)
+const roots = testDirectories.length === 0 ? [__dirname] : testDirectories.map((directory) => path.resolve(directory))
+for (const root of roots) addTests(root)
+mocha.loadFiles()
+mocha.run((failures) => {
+  process.exitCode = failures === 0 ? 0 : 1
+})

--- a/tests/unit/boat/movement.test.ts
+++ b/tests/unit/boat/movement.test.ts
@@ -179,6 +179,25 @@ describe("BoatPhysics collisions and world readiness", () => {
     expect(rig.boatState.age).toBe(before.age);
   });
 
+  it("does not require the extra top readiness layer above boat bounds", () => {
+    const rig = setupWaterBoat();
+    const before = rig.boatState.clone();
+    const originalGetBlock = rig.world.getBlock.bind(rig.world);
+    const extraTopY = Math.ceil(boatY + rig.boatState.height) + 1;
+
+    rig.world.getBlock = (pos: Vec3) => {
+      if (pos.y === extraTopY) return null;
+      return originalGetBlock(pos);
+    };
+
+    rig.boatState.control.forward = true;
+    simulateBoatTick(rig);
+
+    expect(rig.boatState.worldReady).toBe(true);
+    expect(rig.boatState.age).toBe(before.age + 1);
+    expect(rig.boatState.pos.z).toBeLessThan(before.pos.z);
+  });
+
   it("clone does not share mutable Vec3 or controls", () => {
     const rig = createBoatRig({ version, position: new Vec3(1, 2, 3), floorY: 0 });
     const clone = rig.boatState.clone();

--- a/tests/unit/boat/movement.test.ts
+++ b/tests/unit/boat/movement.test.ts
@@ -1,0 +1,226 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { BoatStatus } from "../../../src/physics/states/boatState";
+import {
+  createBoatRig,
+  fillWaterColumn,
+  simulateBoatTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const waterSurfaceY = 64;
+const boatY = waterSurfaceY - 0.4;
+
+function fillWaterPool(world: ReturnType<typeof createBoatRig>["world"], fromZ: number, toZ: number) {
+  for (let x = -1; x <= 1; x++) {
+    for (let z = fromZ; z <= toZ; z++) {
+      fillWaterColumn(world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    }
+  }
+}
+
+function setupWaterBoat() {
+  const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+  fillWaterPool(rig.world, -1, 1);
+  return rig;
+}
+
+describe("BoatPhysics movement", () => {
+  it("keeps a stationary boat stable on calm water", () => {
+    const rig = setupWaterBoat();
+    for (let i = 0; i < 20; i++) {
+      simulateBoatTick(rig);
+    }
+    expect(Math.abs(rig.boatState.vel.x)).toBeLessThan(0.01);
+    expect(Math.abs(rig.boatState.vel.z)).toBeLessThan(0.01);
+    expect(rig.boatState.pos.y).toBeCloseTo(boatY, 0);
+  });
+
+  it("accelerates forward over the first three ticks", () => {
+    const rig = setupWaterBoat();
+    rig.boatState.control.forward = true;
+
+    const positions: Array<{ x: number; z: number }> = [];
+    for (let i = 0; i < 3; i++) {
+      simulateBoatTick(rig);
+      positions.push({ x: rig.boatState.pos.x, z: rig.boatState.pos.z });
+    }
+
+    expect(positions[2].z).toBeLessThan(positions[1].z);
+    expect(positions[1].z).toBeLessThan(positions[0].z);
+    expect(positions[0].z).toBeLessThan(0);
+  });
+
+  it("moves backward slower than forward", () => {
+    const forwardRig = setupWaterBoat();
+    forwardRig.boatState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateBoatTick(forwardRig);
+    const forwardDistance = Math.hypot(forwardRig.boatState.pos.x, forwardRig.boatState.pos.z);
+
+    const backRig = setupWaterBoat();
+    backRig.boatState.control.back = true;
+    for (let i = 0; i < 10; i++) simulateBoatTick(backRig);
+    const backDistance = Math.hypot(backRig.boatState.pos.x, backRig.boatState.pos.z);
+
+    expect(forwardDistance).toBeGreaterThan(backDistance * 2);
+  });
+
+  it("turns left and right with opposite yaw deltas", () => {
+    const leftRig = setupWaterBoat();
+    leftRig.boatState.control.left = true;
+    simulateBoatTick(leftRig);
+    const leftYaw = leftRig.boatState.yaw;
+
+    const rightRig = setupWaterBoat();
+    rightRig.boatState.control.right = true;
+    simulateBoatTick(rightRig);
+    const rightYaw = rightRig.boatState.yaw;
+
+    expect(leftYaw).toBeGreaterThan(0);
+    expect(rightYaw).toBeLessThan(0);
+    expect(leftYaw).toBeCloseTo(-rightYaw, 5);
+  });
+
+  it("forward + left follows an arc", () => {
+    const rig = setupWaterBoat();
+    rig.boatState.control.forward = true;
+    rig.boatState.control.left = true;
+    const startYaw = rig.boatState.yaw;
+    simulateBoatTick(rig);
+    expect(rig.boatState.yaw).toBeGreaterThan(startYaw);
+    expect(rig.boatState.pos.z).toBeLessThan(0);
+    expect(Math.abs(rig.boatState.pos.x)).toBeGreaterThan(0);
+  });
+
+  it("coasts after controls are released", () => {
+    const rig = setupWaterBoat();
+    rig.boatState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateBoatTick(rig);
+    const speedAfterInput = Math.hypot(rig.boatState.vel.x, rig.boatState.vel.z);
+    rig.boatState.control.forward = false;
+    rig.boatState.control.back = false;
+    rig.boatState.control.left = false;
+    rig.boatState.control.right = false;
+    simulateBoatTick(rig);
+    const speedAfterRelease = Math.hypot(rig.boatState.vel.x, rig.boatState.vel.z);
+    expect(speedAfterRelease).toBeGreaterThan(0);
+    expect(speedAfterRelease).toBeLessThan(speedAfterInput);
+  });
+});
+
+describe("BoatPhysics collisions and world readiness", () => {
+  it("settles into water when falling from air", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY + 3, 0), floorY: waterSurfaceY - 2 });
+    fillWaterPool(rig.world, -1, 1);
+
+    for (let i = 0; i < 40; i++) {
+      simulateBoatTick(rig);
+    }
+
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+    expect(rig.boatState.pos.y).toBeLessThan(waterSurfaceY);
+    expect(rig.boatState.pos.y).toBeGreaterThan(waterSurfaceY - 1);
+    expect(Math.abs(rig.boatState.vel.y)).toBeLessThan(0.05);
+  });
+
+  it("stops at a shore collision", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    fillWaterPool(rig.world, -2, 0);
+    for (let x = -2; x <= 2; x++) {
+      rig.world.setStone(new Vec3(x, waterSurfaceY - 1, -2));
+      rig.world.setStone(new Vec3(x, waterSurfaceY, -2));
+      rig.world.setStone(new Vec3(x, waterSurfaceY + 1, -2));
+    }
+
+    rig.boatState.control.forward = true;
+    for (let i = 0; i < 30; i++) simulateBoatTick(rig);
+
+    expect(rig.boatState.pos.z).toBeGreaterThan(-2);
+    expect(rig.boatState.isCollidedHorizontally).toBe(true);
+    expect(Math.abs(rig.boatState.vel.z)).toBeLessThan(0.001);
+  });
+
+  it("slides faster on ice than on stone", () => {
+    const stoneRig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY, 0), floorY: waterSurfaceY - 1 });
+    stoneRig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
+    stoneRig.boatState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateBoatTick(stoneRig);
+    const stoneDistance = Math.hypot(stoneRig.boatState.pos.x, stoneRig.boatState.pos.z);
+
+    const iceRig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY, 0), floorY: waterSurfaceY - 1 });
+    iceRig.world.setIce(new Vec3(0, waterSurfaceY - 1, 0));
+    iceRig.boatState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateBoatTick(iceRig);
+    const iceDistance = Math.hypot(iceRig.boatState.pos.x, iceRig.boatState.pos.z);
+
+    expect(iceDistance).toBeGreaterThan(stoneDistance);
+  });
+
+  it("does not mutate state when a required block is unloaded", () => {
+    const rig = setupWaterBoat();
+    const before = rig.boatState.clone();
+    const originalGetBlock = rig.world.getBlock.bind(rig.world);
+    rig.world.getBlock = (pos: Vec3) => {
+      if (pos.x === 0 && pos.z === 0 && pos.y === waterSurfaceY - 1) return null;
+      return originalGetBlock(pos);
+    };
+
+    simulateBoatTick(rig);
+    expect(rig.boatState.worldReady).toBe(false);
+    expect(rig.boatState.pos.x).toBe(before.pos.x);
+    expect(rig.boatState.pos.y).toBe(before.pos.y);
+    expect(rig.boatState.pos.z).toBe(before.pos.z);
+    expect(rig.boatState.vel.x).toBe(before.vel.x);
+    expect(rig.boatState.vel.y).toBe(before.vel.y);
+    expect(rig.boatState.vel.z).toBe(before.vel.z);
+    expect(rig.boatState.yaw).toBe(before.yaw);
+    expect(rig.boatState.status).toBe(before.status);
+    expect(rig.boatState.age).toBe(before.age);
+  });
+
+  it("clone does not share mutable Vec3 or controls", () => {
+    const rig = createBoatRig({ version, position: new Vec3(1, 2, 3), floorY: 0 });
+    const clone = rig.boatState.clone();
+    clone.pos.x = 99;
+    clone.vel.z = 88;
+    clone.control.forward = true;
+    expect(rig.boatState.pos.x).toBe(1);
+    expect(rig.boatState.vel.z).toBe(0);
+    expect(rig.boatState.control.forward).toBe(false);
+  });
+});
+
+describe("BoatPhysics paddles", () => {
+  it("maps forward to both paddles", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.forward = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(true);
+    expect(paddles.rightPaddle).toBe(true);
+  });
+
+  it("does not activate paddles when moving backward", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.back = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(false);
+    expect(paddles.rightPaddle).toBe(false);
+  });
+
+  it("maps right-only input to left paddle", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.right = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(true);
+    expect(paddles.rightPaddle).toBe(false);
+  });
+
+  it("maps left-only input to right paddle", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.left = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(false);
+    expect(paddles.rightPaddle).toBe(true);
+  });
+});

--- a/tests/unit/boat/status.test.ts
+++ b/tests/unit/boat/status.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { BoatStatus } from "../../../src/physics/states/boatState";
+import {
+  createBoatRig,
+  fillWaterColumn,
+  simulateBoatTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const waterSurfaceY = 64;
+const boatY = waterSurfaceY - 0.4;
+
+describe("BoatPhysics status detection", () => {
+  it("detects IN_WATER on source water", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+  });
+
+  it("detects UNDER_WATER when top is submerged in source water", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY, 0);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_WATER);
+  });
+
+  it("detects UNDER_FLOWING_WATER for falling water above the boat top", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    rig.world.setWater(new Vec3(0, waterSurfaceY, 0), 8);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_FLOWING_WATER);
+  });
+
+  it("normalizes UNDER_WATER to IN_WATER on first tick from air", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY, 0);
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+  });
+
+  it("detects ON_LAND when resting on solid ground", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY, 0), floorY: waterSurfaceY - 1 });
+    rig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.ON_LAND);
+  });
+
+  it("detects IN_AIR when no water or ground contact", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY + 5, 0), floorY: waterSurfaceY - 1 });
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_AIR);
+  });
+});
+
+describe("BoatPhysics fluid height", () => {
+  it("treats water level 8 as flowing, not source", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    rig.world.setWater(new Vec3(0, waterSurfaceY - 1, 0), 8);
+    simulateBoatTick(rig);
+    expect(Number(rig.world.getBlock(new Vec3(0, waterSurfaceY - 1, 0))!.getProperties().level)).toBe(8);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+  });
+
+  it("treats steady-state submerged boat in level 1 water as UNDER_FLOWING_WATER", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.9, 0), floorY: waterSurfaceY - 2 });
+    rig.world.setWater(new Vec3(0, waterSurfaceY - 1, 0), 1);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    for (let i = 0; i < 5; i++) {
+      simulateBoatTick(rig);
+    }
+    expect(Number(rig.world.getBlock(new Vec3(0, waterSurfaceY - 1, 0))!.getProperties().level)).toBe(1);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_FLOWING_WATER);
+  });
+
+  it("raises fluid height to 1 when the block above is also water", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY, 0);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_WATER);
+  });
+});

--- a/tests/unit/horse/jump.test.ts
+++ b/tests/unit/horse/jump.test.ts
@@ -1,0 +1,149 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { HorseState } from "../../../src/physics/states/horseState";
+import {
+  createHorseRig,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const groundY = 64;
+
+function setupGroundHorse() {
+  return createHorseRig({
+    version,
+    position: new Vec3(0, groundY, 0),
+    floorY: groundY - 1,
+    attributes: {
+      "generic.movement_speed": { value: 0.225, modifiers: [] },
+      "horse.jump_strength": { value: 0.7, modifiers: [] },
+    },
+  });
+}
+
+describe("HorsePhysics jump", () => {
+  it("starts at zero and charges linearly through the tenth held tick", () => {
+    const rig = setupGroundHorse();
+    for (let tick = 0; tick <= 10; tick++) {
+      rig.horseState.updateJumpCharge(true);
+      expect(rig.horseState.jumpChargeScale).toBeCloseTo(Math.min(tick * 0.1, 1), 5);
+    }
+  });
+
+  it("falls from 1.0 toward the vanilla 0.8 long-hold limit", () => {
+    const rig = setupGroundHorse();
+    for (let tick = 0; tick < 20; tick++) {
+      rig.horseState.updateJumpCharge(true);
+    }
+    expect(rig.horseState.jumpChargeScale).toBeGreaterThan(0.8);
+    expect(rig.horseState.jumpChargeScale).toBeLessThan(0.9);
+  });
+
+  it("sets pending scale on release with minimum 0.4 for quick tap", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.updateJumpCharge(true);
+    const release = rig.horseState.updateJumpCharge(false);
+    expect(release.released).toBe(true);
+    expect(release.jumpBoost).toBe(0);
+    expect(rig.horseState.jumpPendingScale).toBeCloseTo(0.4, 5);
+  });
+
+  it("applies charge-dependent vertical jump on ground", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.jumpPendingScale = 1.0;
+    rig.horseState.onGround = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBeGreaterThan(0.5);
+  });
+
+  it("adds forward horizontal impulse when jumping forward", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.control.forward = true;
+    rig.horseState.jumpPendingScale = 1.0;
+    rig.horseState.onGround = true;
+    const beforeZ = rig.horseState.pos.z;
+    simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeLessThan(beforeZ);
+  });
+
+  it("lands and allows repeated jumps", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.jumpPendingScale = 1.0;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBeGreaterThan(0);
+
+    for (let i = 0; i < 30; i++) simulateHorseTick(rig);
+    expect(rig.horseState.onGround).toBe(true);
+
+    rig.horseState.jumpPendingScale = 0.5;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBeGreaterThan(0);
+  });
+
+  it("uses honey block jump factor", () => {
+    const rig = setupGroundHorse();
+    const honeyId = rig.mcData.blocksByName.honey_block?.id;
+    if (honeyId != null) {
+      rig.world.setBlock(new Vec3(0, groundY, 0), honeyId);
+    }
+    rig.horseState.jumpPendingScale = 1.0;
+    simulateHorseTick(rig);
+    const honeyJump = rig.horseState.vel.y;
+
+    const normalRig = setupGroundHorse();
+    normalRig.horseState.jumpPendingScale = 1.0;
+    simulateHorseTick(normalRig);
+    if (honeyId != null) {
+      expect(honeyJump).toBeLessThan(normalRig.horseState.vel.y);
+    }
+  });
+
+  it("reads jump strength from entity attributes", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+      attributes: {
+        "horse.jump_strength": { value: 1.0, modifiers: [] },
+      },
+    });
+    expect(rig.horseState.jumpStrength).toBeCloseTo(1.0, 5);
+  });
+
+  it("clone preserves jump state independently", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.jumpChargeScale = 0.5;
+    rig.horseState.jumpPendingScale = 0.8;
+    const clone = rig.horseState.clone();
+    clone.jumpChargeScale = 0.1;
+    expect(rig.horseState.jumpChargeScale).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe("HorseState attributes", () => {
+  it("uses vanilla defaults before attributes arrive", () => {
+    const state = HorseState.CREATE_FROM_ENTITY({} as any, {
+      position: new Vec3(0, 64, 0),
+      velocity: new Vec3(0, 0, 0),
+      height: 1.6,
+      width: 1.3964844,
+      yaw: 0,
+      pitch: 0,
+    } as any);
+    expect(state.movementSpeed).toBeCloseTo(0.225, 5);
+    expect(state.jumpStrength).toBeCloseTo(0.7, 5);
+  });
+
+  it("applies attribute modifiers without mutating source", () => {
+    const attr = {
+      value: 0.225,
+      modifiers: [{ uuid: "test", operation: 1, amount: 0.5 }],
+    };
+    const speed = HorseState.getMovementSpeedFromAttributes({
+      "generic.movement_speed": attr,
+    });
+    expect(speed).toBeCloseTo(0.3375, 4);
+    expect(attr.modifiers.length).toBe(1);
+  });
+});

--- a/tests/unit/horse/movement.test.ts
+++ b/tests/unit/horse/movement.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import {
+  createHorseRig,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const groundY = 64;
+
+function setupGroundHorse() {
+  return createHorseRig({
+    version,
+    position: new Vec3(0, groundY, 0),
+    floorY: groundY - 1,
+  });
+}
+
+describe("HorsePhysics movement", () => {
+  it("moves forward when forward control is pressed", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeLessThan(0);
+  });
+
+  it("moves backward slower than forward", () => {
+    const forwardRig = setupGroundHorse();
+    forwardRig.horseState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(forwardRig);
+    const forwardDistance = Math.hypot(forwardRig.horseState.pos.x, forwardRig.horseState.pos.z);
+
+    const backRig = setupGroundHorse();
+    backRig.horseState.control.back = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(backRig);
+    const backDistance = Math.hypot(backRig.horseState.pos.x, backRig.horseState.pos.z);
+
+    expect(forwardDistance).toBeGreaterThan(backDistance * 2);
+  });
+
+  it("strafes left and right with opposite X deltas", () => {
+    const leftRig = setupGroundHorse();
+    leftRig.horseState.control.left = true;
+    simulateHorseTick(leftRig);
+    const leftX = leftRig.horseState.pos.x;
+
+    const rightRig = setupGroundHorse();
+    rightRig.horseState.control.right = true;
+    simulateHorseTick(rightRig);
+    const rightX = rightRig.horseState.pos.x;
+
+    expect(leftX).toBeLessThan(0);
+    expect(rightX).toBeGreaterThan(0);
+  });
+
+  it("uses rider yaw for horse rotation", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.updateControls(rig.horseState.control, Math.PI / 2, 0);
+    expect(rig.horseState.yaw).toBeCloseTo(Math.PI / 2, 5);
+  });
+
+  it("sets horse pitch to half rider pitch", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.updateControls(rig.horseState.control, 0, Math.PI / 4);
+    expect(rig.horseState.pitch).toBeCloseTo(Math.PI / 8, 5);
+  });
+
+  it("does not apply sprint speed multiplier", () => {
+    const normalRig = setupGroundHorse();
+    normalRig.horseState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(normalRig);
+    const normalDistance = Math.hypot(normalRig.horseState.pos.x, normalRig.horseState.pos.z);
+
+    const sprintRig = setupGroundHorse();
+    sprintRig.horseState.control.forward = true;
+    sprintRig.horseState.control.sprint = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(sprintRig);
+    const sprintDistance = Math.hypot(sprintRig.horseState.pos.x, sprintRig.horseState.pos.z);
+
+    expect(Math.abs(sprintDistance - normalDistance)).toBeLessThan(0.01);
+  });
+
+  it("steps up a 1-block ledge", () => {
+    const rig = setupGroundHorse();
+    for (let x = -2; x <= 2; x++) {
+      for (let z = -2; z <= 5; z++) {
+        rig.world.setStone(new Vec3(x, groundY - 1, z));
+      }
+    }
+    rig.world.setStone(new Vec3(0, groundY, -3));
+    rig.horseState.control.forward = true;
+    for (let i = 0; i < 20; i++) simulateHorseTick(rig);
+    expect(rig.horseState.pos.y).toBeGreaterThanOrEqual(groundY);
+  });
+
+  it("collides with a wall", () => {
+    const rig = setupGroundHorse();
+    for (let y = groundY - 1; y <= groundY + 2; y++) {
+      rig.world.setStone(new Vec3(0, y, -3));
+    }
+    rig.horseState.control.forward = true;
+    for (let i = 0; i < 30; i++) simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeGreaterThan(-2.5);
+  });
+
+  it("moves faster on ice than stone", () => {
+    const iceRig = setupGroundHorse();
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -20; z <= 1; z++) {
+        iceRig.world.setIce(new Vec3(x, groundY - 1, z));
+      }
+    }
+    iceRig.horseState.control.forward = true;
+    for (let i = 0; i < 20; i++) simulateHorseTick(iceRig);
+    const iceSpeed = Math.hypot(iceRig.horseState.vel.x, iceRig.horseState.vel.z);
+
+    const stoneRig = setupGroundHorse();
+    stoneRig.horseState.control.forward = true;
+    for (let i = 0; i < 20; i++) simulateHorseTick(stoneRig);
+    const stoneSpeed = Math.hypot(stoneRig.horseState.vel.x, stoneRig.horseState.vel.z);
+
+    expect(iceSpeed).toBeGreaterThan(stoneSpeed);
+  });
+});

--- a/tests/unit/horse/world.test.ts
+++ b/tests/unit/horse/world.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import {
+  createHorseRig,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const groundY = 64;
+
+describe("HorsePhysics world readiness", () => {
+  it("pauses simulation when required blocks are missing", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    const loadedWorld = rig.world;
+    const worldWithHoles = {
+      getBlock(pos: Vec3) {
+        if (Math.abs(pos.x) > 1 || Math.abs(pos.z) > 1) return null;
+        return loadedWorld.getBlock(pos);
+      },
+    };
+    const before = rig.horseState.pos.clone();
+    rig.horseState.control.forward = true;
+    rig.physics.simulate(rig.horseCtx, worldWithHoles);
+    expect(rig.horseState.worldReady).toBe(false);
+    expect(rig.horseState.pos.equals(before)).toBe(true);
+  });
+
+  it("rebaseFromEntity updates position without mutating jump charge", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    rig.horseState.jumpChargeScale = 0.5;
+    rig.horseState.rebaseFromEntity({
+      position: new Vec3(5, groundY, 5),
+      velocity: new Vec3(0, 0, 0),
+      yaw: 1,
+      pitch: 0.5,
+      onGround: true,
+      height: 1.6,
+      width: 1.3964844,
+    } as any);
+    expect(rig.horseState.pos.x).toBe(5);
+    expect(rig.horseState.jumpChargeScale).toBeCloseTo(0.5, 5);
+  });
+
+  it("keeps finite state after simulation", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    rig.horseState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(rig);
+    expect([rig.horseState.pos.x, rig.horseState.pos.y, rig.horseState.pos.z,
+      rig.horseState.vel.x, rig.horseState.vel.y, rig.horseState.vel.z,
+      rig.horseState.yaw, rig.horseState.pitch].every(Number.isFinite)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Add boat and horse physics

### Context

This is the foundational physics PR for the controlled-vehicle implementation
(boats and ridden horses).

The existing entity physics did not model vanilla boat or horse behavior. Boats
need water-state detection, buoyancy, steering, land friction, and paddle state;
ridden horses need attribute-driven speed/jump, a jump-charge mechanic, ground
friction, and fluid handling. Both require dedicated, entity-specific simulation.

The horse movement matches the current (1.21.x) vanilla physics and behaves well
in testing. It is also intended to work on 1.17.

### Implementation

**Boats**

- Add `BoatState` with:
  - current and previous water/land status;
  - water level and land friction;
  - yaw velocity and last vertical velocity;
  - controlling-player and world-readiness state.
- Add `BoatPhysics` behavior for:
  - source and flowing water detection;
  - underwater, in-water, on-land, and in-air states;
  - gravity, buoyancy, and water-entry transitions;
  - forward/backward acceleration and steering;
  - paddle state calculation;
  - collision handling;
  - stone and ice friction.
- Skip simulation when required world blocks are not loaded.

**Horses**

- Add `HorseState` with:
  - movement speed and jump strength read from entity attributes
    (`generic.movement_speed`, `horse.jump_strength`), with vanilla defaults
    used until attributes arrive;
  - saddle status from entity metadata;
  - a jump-charge model (charge ticks/scale, pending jump scale, jump-boost
    output) matching the vanilla charge-and-release curve;
  - rider-driven yaw/pitch and travel input (forward/back/strafe scaling,
    reduced backward speed);
  - `rebaseFromEntity` / `applyToEntity` sync and world-readiness state.
- Add `HorsePhysics` behavior (extending the shared entity physics) for:
  - gravity, air/ground inertia, and vertical drag;
  - attribute-driven ground acceleration influenced by block friction;
  - ground jump with charge-scaled height, jump-boost, honey-block jump factor,
    and forward horizontal impulse when jumping while moving forward;
  - 1-block auto step-up and horizontal-collision handling;
  - stone-vs-ice ground friction;
  - travel in water and lava (buoyancy, slowdown, ledge escape);
  - world-readiness gating over the swept/step block range.

**Shared / housekeeping**

- Export `BoatPhysics`, `BoatState`, `BoatStatus`, `HorsePhysics`, and
  `HorseState` from the public package entry point.
- Move `getPose` into `poses.ts` and switch several cross-module imports to
  type-only to avoid circular-import issues introduced by the new states.

### Testing

Focused unit coverage was added for:

- **Boats:** water and land status detection; source and flowing water;
  buoyancy and water entry; acceleration, steering, and input release; paddle
  states; shore collisions; stone versus ice friction; unloaded world data;
  state cloning and mutable-state isolation.
- **Horses:** jump charge/hold/release curve and pending-scale minimums;
  charge-dependent vertical jump; forward jump impulse; repeated jumps after
  landing; honey-block jump factor; attribute-driven speed and jump strength
  (including modifier application without mutating the source); no sprint
  multiplier; forward/backward/strafe movement; 1-block step-up; wall
  collision; ice-vs-stone friction; world-readiness pausing; `rebaseFromEntity`
  without corrupting jump charge; finite-state stability.

### Related PRs

- Required by [zardoy/mineflayer#9](https://github.com/zardoy/mineflayer/pull/9)
- Integrated into the browser client by [zardoy/minecraft-web-client#590](https://github.com/zardoy/minecraft-web-client/pull/590).

### Scope

This PR provides the reusable boat and horse simulation only. Mineflayer
lifecycle, protocol packets, client integration, and rendering are handled in
the related PRs.

Minecart physics is intentionally not part of this PR. In our testing minecarts
already behave well through the existing generic entity-physics path, so no
changes were needed here. If review surfaces any issues, we'll look into them
and follow up with fixes.

