### PR TITLE
feat(physics): add multiversion boat physics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ export { PhysicsUtilWrapper } from "./wrapper";
 
 export { EPhysicsCtx, PhysicsWorldSettings } from "./physics/settings";
 export { BaseSimulator } from "./simulators";
-export { EntityPhysics, BotcraftPhysics } from "./physics/engines";
-export { EntityState, PlayerState, PlayerPoses, IEntityState } from "./physics/states";
+export { EntityPhysics, BotcraftPhysics, BoatPhysics } from "./physics/engines";
+export { EntityState, PlayerState, PlayerPoses, IEntityState, BoatState, BoatStatus } from "./physics/states";
 export { ControlStateHandler } from "./physics/player";
 
 export type { SimulationGoal, Controller, OnGoalReachFunction }from "./simulators";

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -17,7 +17,6 @@ const FLOWING_WATER_VERTICAL = Math.fround(-0.0007);
 const ROTATION_PER_TICK = Math.PI / 180;
 const DEFAULT_BLOCK_FRICTION = 0.6;
 const MAX_CONTROL_ACCELERATION = Math.fround(0.04);
-const MAX_VERTICAL_MOTION = Math.fround(GRAVITY + BUOYANCY_UNDER_WATER + 0.101);
 
 export class BoatPhysics extends EntityPhysics {
   constructor(mcData: md.IndexedData) {
@@ -52,7 +51,7 @@ export class BoatPhysics extends EntityPhysics {
     return this.getEntityBB(simCtx, state.pos);
   }
 
-  private getWorldQueryBlockRange(simCtx: EPhysicsCtx, state: BoatState): {
+  private getWorldReadinessBlockRange(simCtx: EPhysicsCtx, state: BoatState): {
     minX: number;
     maxX: number;
     minY: number;
@@ -61,33 +60,25 @@ export class BoatPhysics extends EntityPhysics {
     maxZ: number;
   } {
     const bb = this.getBoatBB(simCtx, state);
-    const sweepX = Math.abs(state.vel.x) + MAX_CONTROL_ACCELERATION;
-    const sweepY = Math.max(Math.abs(state.vel.y), Math.abs(state.lastVerticalVelocity), MAX_VERTICAL_MOTION);
-    const sweepZ = Math.abs(state.vel.z) + MAX_CONTROL_ACCELERATION;
-
-    const sweptMinX = bb.minX - sweepX;
-    const sweptMaxX = bb.maxX + sweepX;
-    const sweptMinY = bb.minY - sweepY;
-    const sweptMaxY = bb.maxY + sweepY + 0.001;
-    const sweptMinZ = bb.minZ - sweepZ;
-    const sweptMaxZ = bb.maxZ + sweepZ;
+    const margin = 1;
 
     return {
-      minX: Math.floor(sweptMinX) - 1,
-      maxX: Math.ceil(sweptMaxX) + 1,
-      minY: Math.floor(sweptMinY) - 1,
+      minX: Math.floor(bb.minX) - margin,
+      maxX: Math.ceil(bb.maxX) + margin,
+      minY: Math.floor(bb.minY) - margin,
       maxY: Math.max(
-        Math.ceil(sweptMaxY) + 1,
-        Math.ceil(bb.maxY - state.lastVerticalVelocity) + 1,
-        Math.ceil(bb.maxY) + 1,
+        Math.ceil(bb.maxY) + margin,
+        Math.ceil(bb.maxY - state.lastVerticalVelocity) + margin,
+        Math.ceil(bb.maxY + 0.001) + margin,
+        Math.ceil(bb.minY + 0.001) + margin,
       ),
-      minZ: Math.floor(sweptMinZ) - 1,
-      maxZ: Math.ceil(sweptMaxZ) + 1,
+      minZ: Math.floor(bb.minZ) - margin,
+      maxZ: Math.ceil(bb.maxZ) + margin,
     };
   }
 
   private isWorldReady(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): boolean {
-    const range = this.getWorldQueryBlockRange(simCtx, state);
+    const range = this.getWorldReadinessBlockRange(simCtx, state);
     const cursor = new Vec3(0, 0, 0);
 
     for (cursor.y = range.minY; cursor.y <= range.maxY; cursor.y++) {
@@ -296,12 +287,18 @@ export class BoatPhysics extends EntityPhysics {
       state.status !== BoatStatus.ON_LAND
     ) {
       const bb = this.getBoatBB(simCtx, state);
+      state.waterLevel = bb.maxY;
       const waterLevelAbove = this.getWaterLevelAbove(bb, state.lastVerticalVelocity, world);
       const targetY = waterLevelAbove - state.height + 0.101;
       const dy = targetY - state.pos.y;
-      this.moveEntity(simCtx, 0, dy, 0, world);
-      state.vel.y = 0;
-      state.lastVerticalVelocity = 0;
+      const targetPos = { x: state.pos.x, y: state.pos.y + dy, z: state.pos.z };
+      const targetBB = this.getEntityBB(simCtx, targetPos);
+      const hasSolidCollision = this.getSurroundingBBs(targetBB, world).some((bb) => targetBB.intersects(bb));
+      if (dy !== 0 && !hasSolidCollision) {
+        this.moveEntity(simCtx, 0, dy, 0, world);
+        state.vel.y = 0;
+        state.lastVerticalVelocity = 0;
+      }
       state.status = BoatStatus.IN_WATER;
       return;
     }
@@ -324,6 +321,9 @@ export class BoatPhysics extends EntityPhysics {
         break;
       case BoatStatus.ON_LAND:
         invFriction = state.landFriction;
+        if (state.controllingPlayer) {
+          state.landFriction /= 2;
+        }
         break;
     }
 

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -81,7 +81,7 @@ export class BoatPhysics extends EntityPhysics {
     const range = this.getWorldReadinessBlockRange(simCtx, state);
     const cursor = new Vec3(0, 0, 0);
 
-    for (cursor.y = range.minY; cursor.y <= range.maxY; cursor.y++) {
+    for (cursor.y = range.minY; cursor.y < range.maxY; cursor.y++) {
       for (cursor.z = range.minZ; cursor.z < range.maxZ; cursor.z++) {
         for (cursor.x = range.minX; cursor.x < range.maxX; cursor.x++) {
           if (world.getBlock(cursor) == null) {
@@ -354,7 +354,7 @@ export class BoatPhysics extends EntityPhysics {
     state.yaw += state.yawVelocity;
 
     if (control.forward) {
-      acceleration += Math.fround(0.04);
+      acceleration += MAX_CONTROL_ACCELERATION;
     }
     if (control.back) {
       acceleration -= Math.fround(0.005);

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -51,6 +51,18 @@ export class BoatPhysics extends EntityPhysics {
     return this.getEntityBB(simCtx, state.pos);
   }
 
+  private hasSolidCollision(targetBB: AABB, solidBB: AABB): boolean {
+    const epsilon = 1e-7;
+    return (
+      targetBB.minX < solidBB.maxX - epsilon &&
+      targetBB.maxX > solidBB.minX + epsilon &&
+      targetBB.minY < solidBB.maxY - epsilon &&
+      targetBB.maxY > solidBB.minY + epsilon &&
+      targetBB.minZ < solidBB.maxZ - epsilon &&
+      targetBB.maxZ > solidBB.minZ + epsilon
+    );
+  }
+
   private getWorldReadinessBlockRange(simCtx: EPhysicsCtx, state: BoatState): {
     minX: number;
     maxX: number;
@@ -291,10 +303,19 @@ export class BoatPhysics extends EntityPhysics {
       const waterLevelAbove = this.getWaterLevelAbove(bb, state.lastVerticalVelocity, world);
       const targetY = waterLevelAbove - state.height + 0.101;
       const dy = targetY - state.pos.y;
+      const useCollisionGuard = this.supportFeature("boatWaterEntryCollisionGuard");
       const targetPos = { x: state.pos.x, y: state.pos.y + dy, z: state.pos.z };
       const targetBB = this.getEntityBB(simCtx, targetPos);
-      const hasSolidCollision = this.getSurroundingBBs(targetBB, world).some((bb) => targetBB.intersects(bb));
-      if (dy !== 0 && !hasSolidCollision) {
+      const hasSolidCollision = this.getSurroundingBBs(targetBB, world).some((solidBB) =>
+        this.hasSolidCollision(targetBB, solidBB),
+      );
+      if (!useCollisionGuard) {
+        if (dy !== 0) {
+          this.moveEntity(simCtx, 0, dy, 0, world);
+        }
+        state.vel.y = 0;
+        state.lastVerticalVelocity = 0;
+      } else if (dy !== 0 && !hasSolidCollision) {
         this.moveEntity(simCtx, 0, dy, 0, world);
         state.vel.y = 0;
         state.lastVerticalVelocity = 0;

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -1,0 +1,376 @@
+import { AABB } from "@nxg-org/mineflayer-util-plugin";
+import md from "minecraft-data";
+import { Block } from "prismarine-block";
+import { Vec3 } from "vec3";
+import { EPhysicsCtx } from "../settings/entityPhysicsCtx";
+import { BoatState, BoatStatus } from "../states/boatState";
+import { IEntityState } from "../states";
+import { EntityPhysics } from "./entityPhysics";
+
+type PhysicsWorld = {
+  getBlock(pos: Vec3): Block | null | undefined;
+};
+
+const GRAVITY = Math.fround(0.04);
+const BUOYANCY_UNDER_WATER = Math.fround(0.01);
+const FLOWING_WATER_VERTICAL = Math.fround(-0.0007);
+const ROTATION_PER_TICK = Math.PI / 180;
+const DEFAULT_BLOCK_FRICTION = 0.6;
+const MAX_CONTROL_ACCELERATION = Math.fround(0.04);
+const MAX_VERTICAL_MOTION = Math.fround(GRAVITY + BUOYANCY_UNDER_WATER + 0.101);
+
+export class BoatPhysics extends EntityPhysics {
+  constructor(mcData: md.IndexedData) {
+    super(mcData);
+  }
+
+  simulate(simCtx: EPhysicsCtx, world: PhysicsWorld): IEntityState {
+    if (!(simCtx.state instanceof BoatState)) {
+      return super.simulate(simCtx, world);
+    }
+
+    const state = simCtx.state;
+    if (!this.isWorldReady(simCtx, state, world)) {
+      state.worldReady = false;
+      return state;
+    }
+
+    state.worldReady = true;
+
+    state.previousStatus = state.status;
+    state.status = this.getStatus(simCtx, state, world);
+    this.floatBoat(simCtx, state, world);
+    this.controlBoat(state);
+    state.lastVerticalVelocity = state.vel.y;
+
+    this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
+    state.age++;
+    return state;
+  }
+
+  private getBoatBB(simCtx: EPhysicsCtx, state: BoatState): AABB {
+    return this.getEntityBB(simCtx, state.pos);
+  }
+
+  private getWorldQueryBlockRange(simCtx: EPhysicsCtx, state: BoatState): {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    minZ: number;
+    maxZ: number;
+  } {
+    const bb = this.getBoatBB(simCtx, state);
+    const sweepX = Math.abs(state.vel.x) + MAX_CONTROL_ACCELERATION;
+    const sweepY = Math.max(Math.abs(state.vel.y), Math.abs(state.lastVerticalVelocity), MAX_VERTICAL_MOTION);
+    const sweepZ = Math.abs(state.vel.z) + MAX_CONTROL_ACCELERATION;
+
+    const sweptMinX = bb.minX - sweepX;
+    const sweptMaxX = bb.maxX + sweepX;
+    const sweptMinY = bb.minY - sweepY;
+    const sweptMaxY = bb.maxY + sweepY + 0.001;
+    const sweptMinZ = bb.minZ - sweepZ;
+    const sweptMaxZ = bb.maxZ + sweepZ;
+
+    return {
+      minX: Math.floor(sweptMinX) - 1,
+      maxX: Math.ceil(sweptMaxX) + 1,
+      minY: Math.floor(sweptMinY) - 1,
+      maxY: Math.max(
+        Math.ceil(sweptMaxY) + 1,
+        Math.ceil(bb.maxY - state.lastVerticalVelocity) + 1,
+        Math.ceil(bb.maxY) + 1,
+      ),
+      minZ: Math.floor(sweptMinZ) - 1,
+      maxZ: Math.ceil(sweptMaxZ) + 1,
+    };
+  }
+
+  private isWorldReady(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): boolean {
+    const range = this.getWorldQueryBlockRange(simCtx, state);
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = range.minY; cursor.y <= range.maxY; cursor.y++) {
+      for (cursor.z = range.minZ; cursor.z < range.maxZ; cursor.z++) {
+        for (cursor.x = range.minX; cursor.x < range.maxX; cursor.x++) {
+          if (world.getBlock(cursor) == null) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  private getStatus(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): BoatStatus {
+    const bb = this.getBoatBB(simCtx, state);
+    const underwater = this.isUnderwater(bb, world);
+    if (underwater != null) {
+      state.waterLevel = bb.maxY;
+      return underwater;
+    }
+    if (this.checkInWater(bb, state, world)) {
+      return BoatStatus.IN_WATER;
+    }
+    const groundFriction = this.getGroundFriction(bb, world);
+    if (groundFriction > 0) {
+      state.landFriction = groundFriction;
+      return BoatStatus.ON_LAND;
+    }
+    return BoatStatus.IN_AIR;
+  }
+
+  private isUnderwater(bb: AABB, world: PhysicsWorld): BoatStatus | null {
+    const topY = bb.maxY + 0.001;
+    const minX = Math.floor(bb.minX);
+    const maxX = Math.ceil(bb.maxX);
+    const minY = Math.floor(bb.maxY);
+    const maxY = Math.ceil(topY);
+    const minZ = Math.floor(bb.minZ);
+    const maxZ = Math.ceil(bb.maxZ);
+    let foundSource = false;
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+      for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+        for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+          const block = world.getBlock(cursor);
+          if (!this.isWaterBlock(block)) continue;
+          const fluidHeight = cursor.y + this.getFluidHeight(block, world, cursor);
+          if (topY < fluidHeight) {
+            if (!this.isSourceWater(block)) {
+              return BoatStatus.UNDER_FLOWING_WATER;
+            }
+            foundSource = true;
+          }
+        }
+      }
+    }
+
+    return foundSource ? BoatStatus.UNDER_WATER : null;
+  }
+
+  private checkInWater(bb: AABB, state: BoatState, world: PhysicsWorld): boolean {
+    const minX = Math.floor(bb.minX);
+    const maxX = Math.ceil(bb.maxX);
+    const minY = Math.floor(bb.minY);
+    const maxY = Math.ceil(bb.minY + 0.001);
+    const minZ = Math.floor(bb.minZ);
+    const maxZ = Math.ceil(bb.maxZ);
+    let inWater = false;
+    state.waterLevel = -Infinity;
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+      for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+        for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+          const block = world.getBlock(cursor);
+          if (!this.isWaterBlock(block)) continue;
+          const fluidHeight = cursor.y + this.getFluidHeight(block, world, cursor);
+          state.waterLevel = Math.max(state.waterLevel, fluidHeight);
+          inWater ||= bb.minY < fluidHeight;
+        }
+      }
+    }
+
+    return inWater;
+  }
+
+  private getWaterLevelAbove(bb: AABB, lastVerticalVelocity: number, world: PhysicsWorld): number {
+    const minX = Math.floor(bb.minX);
+    const maxX = Math.ceil(bb.maxX);
+    const minY = Math.floor(bb.maxY);
+    const maxY = Math.ceil(bb.maxY - lastVerticalVelocity);
+    const minZ = Math.floor(bb.minZ);
+    const maxZ = Math.ceil(bb.maxZ);
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+      let maxSliceHeight = 0;
+      for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+        for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+          const block = world.getBlock(cursor);
+          if (!this.isWaterBlock(block)) continue;
+          maxSliceHeight = Math.max(maxSliceHeight, this.getFluidHeight(block, world, cursor));
+          if (maxSliceHeight >= 1) break;
+        }
+        if (maxSliceHeight >= 1) break;
+      }
+
+      if (maxSliceHeight >= 1) continue;
+      if (maxSliceHeight < 1) {
+        return cursor.y + maxSliceHeight;
+      }
+    }
+
+    return maxY + 1;
+  }
+
+  private getGroundFriction(bb: AABB, world: PhysicsWorld): number {
+    const groundBB = new AABB(bb.minX, bb.minY - 0.001, bb.minZ, bb.maxX, bb.minY, bb.maxZ);
+    const minX = Math.floor(groundBB.minX) - 1;
+    const maxX = Math.ceil(groundBB.maxX) + 1;
+    const minY = Math.floor(groundBB.minY) - 1;
+    const maxY = Math.ceil(groundBB.maxY) + 1;
+    const minZ = Math.floor(groundBB.minZ) - 1;
+    const maxZ = Math.ceil(groundBB.maxZ) + 1;
+    let frictionSum = 0;
+    let count = 0;
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.x = minX; cursor.x < maxX; cursor.x++) {
+      for (cursor.z = minZ; cursor.z < maxZ; cursor.z++) {
+        const edgeX = cursor.x === minX || cursor.x === maxX - 1;
+        const edgeZ = cursor.z === minZ || cursor.z === maxZ - 1;
+        const edge = (edgeX ? 1 : 0) + (edgeZ ? 1 : 0);
+        if (edge === 2) continue;
+
+        for (cursor.y = minY; cursor.y < maxY; cursor.y++) {
+          if (edge <= 0 || (cursor.y !== minY && cursor.y !== maxY - 1)) {
+            const block = world.getBlock(cursor);
+            if (!block || block.boundingBox === "empty") continue;
+            if (block.name === "lily_pad") continue;
+            const shapes = block.shapes;
+            if (!shapes?.length) continue;
+            for (const shape of shapes) {
+              const blockBB = new AABB(shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]);
+              blockBB.translate(cursor.x, cursor.y, cursor.z);
+              if (blockBB.intersects(groundBB)) {
+                frictionSum += this.blockSlipperiness[block.type] ?? DEFAULT_BLOCK_FRICTION;
+                count++;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return count > 0 ? frictionSum / count : 0;
+  }
+
+  private isWaterBlock(block: Block | null | undefined): block is Block {
+    if (!block) return false;
+    return block.type === this.waterId || this.waterLike.has(block.type) || !!block.getProperties().waterlogged;
+  }
+
+  private isSameFluid(block: Block, other: Block | null | undefined): boolean {
+    if (!other) return false;
+    if (block.type === this.waterId) {
+      return other.type === this.waterId || !!other.getProperties().waterlogged || this.waterLike.has(other.type);
+    }
+    if (block.getProperties().waterlogged) {
+      return this.isWaterBlock(other);
+    }
+    if (this.waterLike.has(block.type)) {
+      return block.type === other.type || this.isWaterBlock(other);
+    }
+    return false;
+  }
+
+  private isSourceWater(block: Block): boolean {
+    if (block.getProperties().waterlogged) return true;
+    if (this.waterLike.has(block.type)) return true;
+    if (block.type !== this.waterId) return false;
+    return Number(block.getProperties().level) === 0;
+  }
+
+  private getFluidHeight(block: Block, world: PhysicsWorld, pos: Vec3): number {
+    const above = world.getBlock(pos.offset(0, 1, 0));
+    if (this.isSameFluid(block, above)) {
+      return 1;
+    }
+    if (block.getProperties().waterlogged || this.waterLike.has(block.type) || block.type === this.waterId) {
+      return 1 - this.getLiquidHeightPcent(block);
+    }
+    return 0;
+  }
+
+  private floatBoat(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): void {
+    let gravity = -GRAVITY;
+    let buoyancy = 0;
+    let invFriction = Math.fround(0.05);
+
+    if (
+      state.previousStatus === BoatStatus.IN_AIR &&
+      state.status !== BoatStatus.IN_AIR &&
+      state.status !== BoatStatus.ON_LAND
+    ) {
+      const bb = this.getBoatBB(simCtx, state);
+      const waterLevelAbove = this.getWaterLevelAbove(bb, state.lastVerticalVelocity, world);
+      const targetY = waterLevelAbove - state.height + 0.101;
+      const dy = targetY - state.pos.y;
+      this.moveEntity(simCtx, 0, dy, 0, world);
+      state.vel.y = 0;
+      state.lastVerticalVelocity = 0;
+      state.status = BoatStatus.IN_WATER;
+      return;
+    }
+
+    switch (state.status) {
+      case BoatStatus.IN_WATER:
+        buoyancy = (state.waterLevel - state.pos.y) / state.height;
+        invFriction = Math.fround(0.9);
+        break;
+      case BoatStatus.UNDER_FLOWING_WATER:
+        gravity = FLOWING_WATER_VERTICAL;
+        invFriction = Math.fround(0.9);
+        break;
+      case BoatStatus.UNDER_WATER:
+        buoyancy = BUOYANCY_UNDER_WATER;
+        invFriction = Math.fround(0.45);
+        break;
+      case BoatStatus.IN_AIR:
+        invFriction = Math.fround(0.9);
+        break;
+      case BoatStatus.ON_LAND:
+        invFriction = state.landFriction;
+        break;
+    }
+
+    state.vel.x = Math.fround(state.vel.x * invFriction);
+    state.vel.y = Math.fround(state.vel.y + gravity);
+    state.vel.z = Math.fround(state.vel.z * invFriction);
+    state.yawVelocity = Math.fround(state.yawVelocity * invFriction);
+
+    if (buoyancy > 0) {
+      state.vel.y = Math.fround((state.vel.y + buoyancy * (GRAVITY / 0.65)) * 0.75);
+    }
+  }
+
+  private controlBoat(state: BoatState): void {
+    const control = state.control;
+    let acceleration = 0;
+
+    if (control.left) {
+      state.yawVelocity += ROTATION_PER_TICK;
+    }
+    if (control.right) {
+      state.yawVelocity -= ROTATION_PER_TICK;
+    }
+    if (control.right !== control.left && !control.forward && !control.back) {
+      acceleration += Math.fround(0.005);
+    }
+
+    state.yaw += state.yawVelocity;
+
+    if (control.forward) {
+      acceleration += Math.fround(0.04);
+    }
+    if (control.back) {
+      acceleration -= Math.fround(0.005);
+    }
+
+    if (acceleration !== 0) {
+      state.vel.x = Math.fround(state.vel.x + -Math.sin(state.yaw) * acceleration);
+      state.vel.z = Math.fround(state.vel.z + -Math.cos(state.yaw) * acceleration);
+    }
+  }
+
+  getPaddleState(state: BoatState): { leftPaddle: boolean; rightPaddle: boolean } {
+    const { left, right, forward } = state.control;
+    return {
+      leftPaddle: (right && !left) || forward,
+      rightPaddle: (left && !right) || forward,
+    };
+  }
+}

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -302,21 +302,15 @@ export class BoatPhysics extends EntityPhysics {
       state.waterLevel = bb.maxY;
       const waterLevelAbove = this.getWaterLevelAbove(bb, state.lastVerticalVelocity, world);
       const targetY = waterLevelAbove - state.height + 0.101;
-      const dy = targetY - state.pos.y;
       const useCollisionGuard = this.supportFeature("boatWaterEntryCollisionGuard");
-      const targetPos = { x: state.pos.x, y: state.pos.y + dy, z: state.pos.z };
+      const targetPos = { x: state.pos.x, y: targetY, z: state.pos.z };
       const targetBB = this.getEntityBB(simCtx, targetPos);
       const hasSolidCollision = this.getSurroundingBBs(targetBB, world).some((solidBB) =>
         this.hasSolidCollision(targetBB, solidBB),
       );
-      if (!useCollisionGuard) {
-        if (dy !== 0) {
-          this.moveEntity(simCtx, 0, dy, 0, world);
-        }
-        state.vel.y = 0;
-        state.lastVerticalVelocity = 0;
-      } else if (dy !== 0 && !hasSolidCollision) {
-        this.moveEntity(simCtx, 0, dy, 0, world);
+      const canReposition = !useCollisionGuard || !hasSolidCollision;
+      if (canReposition) {
+        state.pos.y = targetY;
         state.vel.y = 0;
         state.lastVerticalVelocity = 0;
       }

--- a/src/physics/engines/boatPhysics.ts
+++ b/src/physics/engines/boatPhysics.ts
@@ -3,6 +3,7 @@ import md from "minecraft-data";
 import { Block } from "prismarine-block";
 import { Vec3 } from "vec3";
 import { EPhysicsCtx } from "../settings/entityPhysicsCtx";
+import { BoatPhysicsSettings, resolveBoatSettings } from "../settings/boatSettings";
 import { BoatState, BoatStatus } from "../states/boatState";
 import { IEntityState } from "../states";
 import { EntityPhysics } from "./entityPhysics";
@@ -11,16 +12,12 @@ type PhysicsWorld = {
   getBlock(pos: Vec3): Block | null | undefined;
 };
 
-const GRAVITY = Math.fround(0.04);
-const BUOYANCY_UNDER_WATER = Math.fround(0.01);
-const FLOWING_WATER_VERTICAL = Math.fround(-0.0007);
-const ROTATION_PER_TICK = Math.PI / 180;
-const DEFAULT_BLOCK_FRICTION = 0.6;
-const MAX_CONTROL_ACCELERATION = Math.fround(0.04);
-
 export class BoatPhysics extends EntityPhysics {
+  private readonly boatSettings: BoatPhysicsSettings;
+
   constructor(mcData: md.IndexedData) {
     super(mcData);
+    this.boatSettings = resolveBoatSettings(mcData);
   }
 
   simulate(simCtx: EPhysicsCtx, world: PhysicsWorld): IEntityState {
@@ -36,10 +33,11 @@ export class BoatPhysics extends EntityPhysics {
 
     state.worldReady = true;
 
+    const cfg = simCtx.boat ?? this.boatSettings;
     state.previousStatus = state.status;
-    state.status = this.getStatus(simCtx, state, world);
-    this.floatBoat(simCtx, state, world);
-    this.controlBoat(state);
+    state.status = this.getStatus(simCtx, state, world, cfg);
+    this.floatBoat(simCtx, state, world, cfg);
+    this.controlBoat(state, cfg);
     state.lastVerticalVelocity = state.vel.y;
 
     this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
@@ -105,7 +103,12 @@ export class BoatPhysics extends EntityPhysics {
     return true;
   }
 
-  private getStatus(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): BoatStatus {
+  private getStatus(
+    simCtx: EPhysicsCtx,
+    state: BoatState,
+    world: PhysicsWorld,
+    cfg: BoatPhysicsSettings,
+  ): BoatStatus {
     const bb = this.getBoatBB(simCtx, state);
     const underwater = this.isUnderwater(bb, world);
     if (underwater != null) {
@@ -115,7 +118,7 @@ export class BoatPhysics extends EntityPhysics {
     if (this.checkInWater(bb, state, world)) {
       return BoatStatus.IN_WATER;
     }
-    const groundFriction = this.getGroundFriction(bb, world);
+    const groundFriction = this.getGroundFriction(bb, world, cfg);
     if (groundFriction > 0) {
       state.landFriction = groundFriction;
       return BoatStatus.ON_LAND;
@@ -209,7 +212,7 @@ export class BoatPhysics extends EntityPhysics {
     return maxY + 1;
   }
 
-  private getGroundFriction(bb: AABB, world: PhysicsWorld): number {
+  private getGroundFriction(bb: AABB, world: PhysicsWorld, cfg: BoatPhysicsSettings): number {
     const groundBB = new AABB(bb.minX, bb.minY - 0.001, bb.minZ, bb.maxX, bb.minY, bb.maxZ);
     const minX = Math.floor(groundBB.minX) - 1;
     const maxX = Math.ceil(groundBB.maxX) + 1;
@@ -239,7 +242,7 @@ export class BoatPhysics extends EntityPhysics {
               const blockBB = new AABB(shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]);
               blockBB.translate(cursor.x, cursor.y, cursor.z);
               if (blockBB.intersects(groundBB)) {
-                frictionSum += this.blockSlipperiness[block.type] ?? DEFAULT_BLOCK_FRICTION;
+                frictionSum += this.blockSlipperiness[block.type] ?? cfg.defaultBlockFriction;
                 count++;
               }
             }
@@ -288,10 +291,15 @@ export class BoatPhysics extends EntityPhysics {
     return 0;
   }
 
-  private floatBoat(simCtx: EPhysicsCtx, state: BoatState, world: PhysicsWorld): void {
-    let gravity = -GRAVITY;
+  private floatBoat(
+    simCtx: EPhysicsCtx,
+    state: BoatState,
+    world: PhysicsWorld,
+    cfg: BoatPhysicsSettings,
+  ): void {
+    let gravity = -cfg.gravity;
     let buoyancy = 0;
-    let invFriction = Math.fround(0.05);
+    let invFriction = cfg.fallbackInvFriction;
 
     if (
       state.previousStatus === BoatStatus.IN_AIR &&
@@ -301,7 +309,7 @@ export class BoatPhysics extends EntityPhysics {
       const bb = this.getBoatBB(simCtx, state);
       state.waterLevel = bb.maxY;
       const waterLevelAbove = this.getWaterLevelAbove(bb, state.lastVerticalVelocity, world);
-      const targetY = waterLevelAbove - state.height + 0.101;
+      const targetY = waterLevelAbove - state.height + cfg.waterEntryYOffset;
       const useCollisionGuard = this.supportFeature("boatWaterEntryCollisionGuard");
       const targetPos = { x: state.pos.x, y: targetY, z: state.pos.z };
       const targetBB = this.getEntityBB(simCtx, targetPos);
@@ -321,23 +329,23 @@ export class BoatPhysics extends EntityPhysics {
     switch (state.status) {
       case BoatStatus.IN_WATER:
         buoyancy = (state.waterLevel - state.pos.y) / state.height;
-        invFriction = Math.fround(0.9);
+        invFriction = cfg.inWaterInvFriction;
         break;
       case BoatStatus.UNDER_FLOWING_WATER:
-        gravity = FLOWING_WATER_VERTICAL;
-        invFriction = Math.fround(0.9);
+        gravity = cfg.flowingWaterVerticalAccel;
+        invFriction = cfg.underFlowingWaterInvFriction;
         break;
       case BoatStatus.UNDER_WATER:
-        buoyancy = BUOYANCY_UNDER_WATER;
-        invFriction = Math.fround(0.45);
+        buoyancy = cfg.buoyancyUnderWater;
+        invFriction = cfg.underWaterInvFriction;
         break;
       case BoatStatus.IN_AIR:
-        invFriction = Math.fround(0.9);
+        invFriction = cfg.inAirInvFriction;
         break;
       case BoatStatus.ON_LAND:
         invFriction = state.landFriction;
         if (state.controllingPlayer) {
-          state.landFriction /= 2;
+          state.landFriction /= cfg.controlledLandFrictionDivisor;
         }
         break;
     }
@@ -348,31 +356,33 @@ export class BoatPhysics extends EntityPhysics {
     state.yawVelocity = Math.fround(state.yawVelocity * invFriction);
 
     if (buoyancy > 0) {
-      state.vel.y = Math.fround((state.vel.y + buoyancy * (GRAVITY / 0.65)) * 0.75);
+      state.vel.y = Math.fround(
+        (state.vel.y + buoyancy * (cfg.gravity / cfg.buoyancyGravityDivisor)) * cfg.buoyancyDamping,
+      );
     }
   }
 
-  private controlBoat(state: BoatState): void {
+  private controlBoat(state: BoatState, cfg: BoatPhysicsSettings): void {
     const control = state.control;
     let acceleration = 0;
 
     if (control.left) {
-      state.yawVelocity += ROTATION_PER_TICK;
+      state.yawVelocity += cfg.rotationPerTick;
     }
     if (control.right) {
-      state.yawVelocity -= ROTATION_PER_TICK;
+      state.yawVelocity -= cfg.rotationPerTick;
     }
     if (control.right !== control.left && !control.forward && !control.back) {
-      acceleration += Math.fround(0.005);
+      acceleration += cfg.turnOnlyAcceleration;
     }
 
     state.yaw += state.yawVelocity;
 
     if (control.forward) {
-      acceleration += MAX_CONTROL_ACCELERATION;
+      acceleration += cfg.forwardAcceleration;
     }
     if (control.back) {
-      acceleration -= Math.fround(0.005);
+      acceleration -= cfg.backwardAcceleration;
     }
 
     if (acceleration !== 0) {

--- a/src/physics/engines/index.ts
+++ b/src/physics/engines/index.ts
@@ -1,4 +1,5 @@
 export * from "./entityPhysics"
 export * from "./botcraft"
+export * from "./boatPhysics"
 export * from "./IPhysics"
 

--- a/src/physics/info/entity_physics.json
+++ b/src/physics/info/entity_physics.json
@@ -87,9 +87,34 @@
             }
         },
         "boat": {
-            "gravity": 0.04,
             "airdrag": 1
         }
+    },
+    "boats": {
+        "default": {
+            "gravity": 0.04,
+            "buoyancyUnderWater": 0.01,
+            "flowingWaterVerticalAccel": -0.0007,
+            "rotationPerTick": 0.017453292519943295,
+            "defaultBlockFriction": 0.6,
+            "forwardAcceleration": 0.04,
+            "backwardAcceleration": 0.005,
+            "turnOnlyAcceleration": 0.005,
+            "fallbackInvFriction": 0.05,
+            "inWaterInvFriction": 0.9,
+            "underFlowingWaterInvFriction": 0.9,
+            "underWaterInvFriction": 0.45,
+            "inAirInvFriction": 0.9,
+            "controlledLandFrictionDivisor": 2,
+            "buoyancyGravityDivisor": 0.65,
+            "buoyancyDamping": 0.75,
+            "waterEntryYOffset": 0.101
+        },
+        "fallbackDimensions": {
+            "height": 0.5625,
+            "width": 1.375
+        },
+        "overrides": []
     },
     "shot_entities": {
         "names": ["fireball", "skull"],

--- a/src/physics/info/features.json
+++ b/src/physics/info/features.json
@@ -38,5 +38,10 @@
       "name": "attributesPrefixedByMinecraft",
       "description": "Attributes are prefixed by 'minecraft:'",
       "versions": ["1.19"]
+    },
+    {
+      "name": "boatWaterEntryCollisionGuard",
+      "description": "Boat water-entry reposition requires no solid collision at the target position",
+      "versions": ["1.21"]
     }
   ]

--- a/src/physics/settings/boatSettings.ts
+++ b/src/physics/settings/boatSettings.ts
@@ -1,0 +1,138 @@
+import md from "minecraft-data";
+import info from "../info/entity_physics.json";
+
+/** Boat physics tuning parameters. Dimensions are resolved separately. */
+export interface BoatPhysicsSettings {
+  /** Downward acceleration per tick (float32 in vanilla). */
+  gravity: number;
+  /** Buoyancy force when fully submerged (float32). */
+  buoyancyUnderWater: number;
+  /** Vertical acceleration under flowing water (float32). */
+  flowingWaterVerticalAccel: number;
+  /** Yaw change per tick when turning; equals Math.PI / 180 (double). */
+  rotationPerTick: number;
+  /** Default block slipperiness when block type is unknown (double). */
+  defaultBlockFriction: number;
+  /** Forward control acceleration (float32). */
+  forwardAcceleration: number;
+  /** Backward control acceleration, stored positive (float32). */
+  backwardAcceleration: number;
+  /** Turn-only acceleration when not moving forward/back (float32). */
+  turnOnlyAcceleration: number;
+  /** Inv-friction fallback before status is known (float32). */
+  fallbackInvFriction: number;
+  /** Inv-friction in calm water (float32). */
+  inWaterInvFriction: number;
+  /** Inv-friction under flowing water (float32). */
+  underFlowingWaterInvFriction: number;
+  /** Inv-friction when fully submerged (float32). */
+  underWaterInvFriction: number;
+  /** Inv-friction in air (float32). */
+  inAirInvFriction: number;
+  /** Divisor applied to land friction when a player controls the boat (double). */
+  controlledLandFrictionDivisor: number;
+  /** Divisor for gravity in buoyancy formula (double). */
+  buoyancyGravityDivisor: number;
+  /** Damping multiplier after buoyancy (double). */
+  buoyancyDamping: number;
+  /** Y offset when snapping into water from air (double). */
+  waterEntryYOffset: number;
+}
+
+export interface BoatDimensions {
+  height: number;
+  width: number;
+}
+
+export interface BoatSettingsSection {
+  default: BoatPhysicsSettings;
+  fallbackDimensions: BoatDimensions;
+  overrides: Array<{ versions: string[]; values: Partial<BoatPhysicsSettings> }>;
+}
+
+/** Fields that pass through float32 in vanilla boat arithmetic. */
+export const FLOAT32_FIELDS = [
+  "gravity",
+  "buoyancyUnderWater",
+  "flowingWaterVerticalAccel",
+  "forwardAcceleration",
+  "backwardAcceleration",
+  "turnOnlyAcceleration",
+  "fallbackInvFriction",
+  "inWaterInvFriction",
+  "underFlowingWaterInvFriction",
+  "underWaterInvFriction",
+  "inAirInvFriction",
+] as const;
+
+const boatSection = info.boats as unknown as BoatSettingsSection;
+
+function hasValidDimensions(entity: md.Entity | undefined): entity is md.Entity & { height: number; width: number } {
+  return (
+    entity != null &&
+    typeof entity.height === "number" &&
+    !Number.isNaN(entity.height) &&
+    typeof entity.width === "number" &&
+    !Number.isNaN(entity.width)
+  );
+}
+
+function applyFloat32Normalization(settings: BoatPhysicsSettings): BoatPhysicsSettings {
+  const result = { ...settings };
+  for (const field of FLOAT32_FIELDS) {
+    result[field] = Math.fround(result[field]);
+  }
+  return result;
+}
+
+/** Pure function — exported for override tests. */
+export function resolveBoatSettingsFromSection(
+  mcData: md.IndexedData,
+  section: BoatSettingsSection,
+): BoatPhysicsSettings {
+  const majorVersion = mcData.version.majorVersion!;
+  let settings: BoatPhysicsSettings = { ...section.default };
+
+  for (const override of section.overrides) {
+    if (override.versions.includes(majorVersion)) {
+      settings = { ...settings, ...override.values };
+    }
+  }
+
+  return applyFloat32Normalization(settings);
+}
+
+/** Resolve boat physics from the `boats` section of entity_physics.json. */
+export function resolveBoatSettings(mcData: md.IndexedData): BoatPhysicsSettings {
+  return resolveBoatSettingsFromSection(mcData, boatSection);
+}
+
+/** Resolve boat dimensions from minecraft-data, falling back when missing. */
+export function resolveBoatDimensions(
+  mcData: md.IndexedData,
+  entityName?: string,
+  fallback: BoatDimensions = boatSection.fallbackDimensions,
+): BoatDimensions {
+  if (entityName) {
+    const named = mcData.entitiesByName[entityName];
+    if (hasValidDimensions(named)) {
+      return { height: named.height, width: named.width };
+    }
+  }
+
+  const genericBoat = mcData.entitiesByName.boat;
+  if (hasValidDimensions(genericBoat)) {
+    return { height: genericBoat.height, width: genericBoat.width };
+  }
+
+  for (const name of Object.keys(mcData.entitiesByName)) {
+    if (name.endsWith("_boat") || name.endsWith("_raft")) {
+      const candidate = mcData.entitiesByName[name];
+      if (hasValidDimensions(candidate)) {
+        return { height: candidate.height, width: candidate.width };
+      }
+    }
+  }
+
+  return { ...fallback };
+}

--- a/src/physics/settings/entityPhysicsCtx.ts
+++ b/src/physics/settings/entityPhysicsCtx.ts
@@ -12,6 +12,15 @@ import info from "../info/entity_physics.json";
 import { PhysicsWorldSettings } from "./physicsSettings";
 import { getPose, PlayerState } from "../states";
 
+function isBoatLikeEntity(entityType: md.Entity): boolean {
+    const name = entityType.name ?? "";
+    return name === "boat" || name.endsWith("_boat") || name.endsWith("_raft");
+}
+
+function applyBoatVehiclePhysics(ctx: EPhysicsCtx): void {
+    Object.assign(ctx, info.dead_vehicles.default, info.dead_vehicles.boat);
+}
+
 
 
 function load(data: md.IndexedData) {
@@ -77,7 +86,9 @@ export class EPhysicsCtx<State extends IEntityState=IEntityState> {
     ) {
 
         // TODO cleanup all of this code.
-        if (entityType.type === "player" || !!EPhysicsCtx.mobData[entityType.id]) {
+        if (isBoatLikeEntity(entityType)) {
+            applyBoatVehiclePhysics(this);
+        } else if (entityType.type === "player" || !!EPhysicsCtx.mobData[entityType.id]) {
             // @ts-expect-error
             const additional = info.living_entities[entityType.type];
             Object.assign(this, info.living_entities.default, additional);
@@ -127,8 +138,8 @@ export class EPhysicsCtx<State extends IEntityState=IEntityState> {
                     };
                     break
                 case "other":
-                    if (entityType.name.includes("minecart") || entityType.name.includes("boat")) {
-                        Object.assign(this, info.dead_vehicles.default, entityType.name === "boat" ? info.dead_vehicles.boat : undefined);
+                    if (entityType.name.includes("minecart")) {
+                        Object.assign(this, info.dead_vehicles.default);
                     } else if (entityType.name?.includes("block") || entityType.name?.includes("tnt")) {
                         Object.assign(this, info.blocks.default);
                     } else if (

--- a/src/physics/settings/entityPhysicsCtx.ts
+++ b/src/physics/settings/entityPhysicsCtx.ts
@@ -9,6 +9,7 @@ import { EntityState, IEntityState } from "../states";
 import { playerPoseCtx, PlayerPoses } from "../states/poses";
 
 import info from "../info/entity_physics.json";
+import { BoatPhysicsSettings, resolveBoatSettings } from "./boatSettings";
 import { PhysicsWorldSettings } from "./physicsSettings";
 import { getPose, PlayerState } from "../states";
 
@@ -19,6 +20,7 @@ function isBoatLikeEntity(entityType: md.Entity): boolean {
 
 function applyBoatVehiclePhysics(ctx: EPhysicsCtx): void {
     Object.assign(ctx, info.dead_vehicles.default, info.dead_vehicles.boat);
+    ctx.boat = resolveBoatSettings(ctx.ctx.data);
 }
 
 
@@ -68,6 +70,8 @@ export class EPhysicsCtx<State extends IEntityState=IEntityState> {
         blockEffects: false,
         affectedAfterCollision: true,
     };
+
+    public boat?: BoatPhysicsSettings;
 
     public get position(): Vec3 {
         return this.state.pos

--- a/src/physics/states/boatState.ts
+++ b/src/physics/states/boatState.ts
@@ -1,0 +1,121 @@
+import type { Entity } from "prismarine-entity";
+import { Vec3 } from "vec3";
+import type { IPhysics } from "../engines";
+import { ControlStateHandler } from "../player/playerControls";
+import { EntityState } from "./entityState";
+
+export enum BoatStatus {
+  IN_WATER,
+  UNDER_WATER,
+  UNDER_FLOWING_WATER,
+  ON_LAND,
+  IN_AIR,
+}
+
+export class BoatState extends EntityState {
+  status: BoatStatus = BoatStatus.IN_AIR;
+  previousStatus: BoatStatus = BoatStatus.IN_AIR;
+
+  waterLevel = -Infinity;
+  landFriction = 0;
+  yawVelocity = 0;
+  lastVerticalVelocity = 0;
+  underwaterTicks = 0;
+
+  worldReady = true;
+
+  constructor(
+    ctx: IPhysics,
+    height: number,
+    halfWidth: number,
+    pos: Vec3,
+    vel: Vec3,
+    onGround: boolean,
+    yaw: number,
+    pitch: number,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+  ) {
+    super(ctx, height, halfWidth, pos, vel, onGround, yaw, pitch, control);
+  }
+
+  public static CREATE_FROM_ENTITY(
+    ctx: IPhysics,
+    entity: Entity,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+  ): BoatState {
+    return new BoatState(
+      ctx,
+      entity.height ?? 0.5625,
+      (entity.width ?? 1.375) / 2,
+      entity.position.clone(),
+      entity.velocity.clone(),
+      entity.onGround ?? false,
+      entity.yaw,
+      entity.pitch,
+      control.clone(),
+    );
+  }
+
+  public updateControls(control: ControlStateHandler): BoatState {
+    this.control = control.clone();
+    return this;
+  }
+
+  public rebaseFromEntity(entity: Entity, options?: { replaceVelocity?: boolean }): BoatState {
+    this.pos.set(entity.position.x, entity.position.y, entity.position.z);
+    if (options?.replaceVelocity !== false) {
+      this.vel.set(entity.velocity.x, entity.velocity.y, entity.velocity.z);
+    }
+    this.yaw = entity.yaw;
+    this.pitch = entity.pitch;
+    this.onGround = entity.onGround ?? false;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    this.isCollidedHorizontally = entityExtras.isCollidedHorizontally ?? false;
+    this.isCollidedVertically = entityExtras.isCollidedVertically ?? false;
+    return this;
+  }
+
+  public applyToEntity(entity: Entity) {
+    entity.position.set(this.pos.x, this.pos.y, this.pos.z);
+    entity.velocity.set(this.vel.x, this.vel.y, this.vel.z);
+    entity.yaw = this.yaw;
+    entity.pitch = this.pitch;
+    entity.onGround = this.onGround;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    entityExtras.isCollidedHorizontally = this.isCollidedHorizontally;
+    entityExtras.isCollidedVertically = this.isCollidedVertically;
+    return this;
+  }
+
+  public clone(): BoatState {
+    const other = new BoatState(
+      this.ctx,
+      this.height,
+      this.halfWidth,
+      this.pos.clone(),
+      this.vel.clone(),
+      this.onGround,
+      this.yaw,
+      this.pitch,
+      this.control.clone(),
+    );
+    other.status = this.status;
+    other.previousStatus = this.previousStatus;
+    other.waterLevel = this.waterLevel;
+    other.landFriction = this.landFriction;
+    other.yawVelocity = this.yawVelocity;
+    other.lastVerticalVelocity = this.lastVerticalVelocity;
+    other.underwaterTicks = this.underwaterTicks;
+    other.worldReady = this.worldReady;
+    other.age = this.age;
+    other.isCollidedHorizontally = this.isCollidedHorizontally;
+    other.isCollidedVertically = this.isCollidedVertically;
+    return other;
+  }
+}

--- a/src/physics/states/boatState.ts
+++ b/src/physics/states/boatState.ts
@@ -21,6 +21,7 @@ export class BoatState extends EntityState {
   yawVelocity = 0;
   lastVerticalVelocity = 0;
   underwaterTicks = 0;
+  controllingPlayer = false;
 
   worldReady = true;
 
@@ -112,6 +113,7 @@ export class BoatState extends EntityState {
     other.yawVelocity = this.yawVelocity;
     other.lastVerticalVelocity = this.lastVerticalVelocity;
     other.underwaterTicks = this.underwaterTicks;
+    other.controllingPlayer = this.controllingPlayer;
     other.worldReady = this.worldReady;
     other.age = this.age;
     other.isCollidedHorizontally = this.isCollidedHorizontally;

--- a/src/physics/states/boatState.ts
+++ b/src/physics/states/boatState.ts
@@ -20,7 +20,6 @@ export class BoatState extends EntityState {
   landFriction = 0;
   yawVelocity = 0;
   lastVerticalVelocity = 0;
-  underwaterTicks = 0;
   controllingPlayer = false;
 
   worldReady = true;
@@ -112,7 +111,6 @@ export class BoatState extends EntityState {
     other.landFriction = this.landFriction;
     other.yawVelocity = this.yawVelocity;
     other.lastVerticalVelocity = this.lastVerticalVelocity;
-    other.underwaterTicks = this.underwaterTicks;
     other.controllingPlayer = this.controllingPlayer;
     other.worldReady = this.worldReady;
     other.age = this.age;

--- a/src/physics/states/boatState.ts
+++ b/src/physics/states/boatState.ts
@@ -1,6 +1,7 @@
 import type { Entity } from "prismarine-entity";
 import { Vec3 } from "vec3";
 import type { IPhysics } from "../engines";
+import { resolveBoatDimensions } from "../settings/boatSettings";
 import { ControlStateHandler } from "../player/playerControls";
 import { EntityState } from "./entityState";
 
@@ -43,10 +44,11 @@ export class BoatState extends EntityState {
     entity: Entity,
     control: ControlStateHandler = ControlStateHandler.DEFAULT(),
   ): BoatState {
+    const dims = resolveBoatDimensions(ctx.data, entity.name);
     return new BoatState(
       ctx,
-      entity.height ?? 0.5625,
-      (entity.width ?? 1.375) / 2,
+      entity.height ?? dims.height,
+      (entity.width ?? dims.width) / 2,
       entity.position.clone(),
       entity.velocity.clone(),
       entity.onGround ?? false,

--- a/src/physics/states/index.ts
+++ b/src/physics/states/index.ts
@@ -7,6 +7,7 @@ import { AABB } from "@nxg-org/mineflayer-util-plugin";
 export * from "./entityState"
 export * from "./playerState"
 export * from "./poses"
+export * from "./boatState"
 
 export type Heading = {
     forward: number;

--- a/tests/helpers/unit/botcraftTestSupport.ts
+++ b/tests/helpers/unit/botcraftTestSupport.ts
@@ -193,30 +193,47 @@ export function createBoatTestWorld(version: string, floorY: number) {
   return new BoatTestWorld(mcData.blocksByName, Block, floorY);
 }
 
+export function resolveBoatEntityDescriptor(
+  mcData: ReturnType<typeof md>,
+  entityName: string,
+  version: string,
+) {
+  const descriptor = mcData.entitiesByName[entityName];
+  if (descriptor == null) {
+    throw new Error(
+      `Boat entity descriptor "${entityName}" not found for Minecraft ${version}`,
+    );
+  }
+
+  return descriptor;
+}
+
 export function createBoatRig(options: {
   version: string;
   position: Vec3;
   floorY?: number;
+  entityName?: string;
 }) {
   const { version, position } = options;
+  const entityName = options.entityName ?? "boat";
   const floorY = options.floorY ?? Math.floor(position.y) - 1;
   const { mcData } = loadMcData(version);
 
   const physics = new BoatPhysics(mcData);
-  const boatEntityType = mcData.entitiesByName.boat;
+  const entityDescriptor = resolveBoatEntityDescriptor(mcData, entityName, version);
   const boatState = BoatState.CREATE_FROM_ENTITY(physics, {
     position: position.clone(),
     velocity: new Vec3(0, 0, 0),
     yaw: 0,
     pitch: 0,
-    height: 0.5625,
-    width: 1.375,
+    height: entityDescriptor.height,
+    width: entityDescriptor.width,
     onGround: false,
-    name: "boat",
+    name: entityName,
   } as Entity);
   boatState.control = ControlStateHandler.DEFAULT();
 
-  const boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(physics, boatState, boatEntityType);
+  const boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(physics, boatState, entityDescriptor);
   const world = createBoatTestWorld(version, floorY);
 
   return {
@@ -225,6 +242,8 @@ export function createBoatRig(options: {
     boatState,
     boatCtx,
     world,
+    entityName,
+    entityDescriptor,
   };
 }
 

--- a/tests/helpers/unit/botcraftTestSupport.ts
+++ b/tests/helpers/unit/botcraftTestSupport.ts
@@ -3,11 +3,12 @@ import md from "minecraft-data";
 import block, { Block as PBlock } from "prismarine-block";
 import { Vec3 } from "vec3";
 import { initSetup } from "../../../src";
-import { BotcraftPhysics } from "../../../src/physics/engines";
+import { BotcraftPhysics, BoatPhysics } from "../../../src/physics/engines";
 import { ControlStateHandler } from "../../../src/physics/player";
 import { EPhysicsCtx } from "../../../src/physics/settings";
-import { PlayerState } from "../../../src/physics/states";
+import { BoatState, PlayerState } from "../../../src/physics/states";
 import { applyMdToNewEntity } from "../../../src/util/physicsUtils";
+import type { Entity } from "prismarine-entity";
 
 const initializedVersions = new Set<string>();
 
@@ -133,4 +134,106 @@ export function createBotcraftPlayerRig(options: {
     playerCtx,
     playerState,
   };
+}
+
+export class BoatTestWorld {
+  private readonly overrideBlocks: Record<string, PBlock> = {};
+
+  constructor(
+    private readonly blocksByName: ReturnType<typeof md>["blocksByName"],
+    private readonly Block: typeof PBlock,
+    private readonly floorY: number,
+  ) {}
+
+  setBlock(pos: Vec3, type: number, metadata = 0) {
+    const blockPos = pos.floored();
+    const blockInstance = new this.Block(type, 0, metadata);
+    blockInstance.position = blockPos;
+    this.overrideBlocks[this.keyFor(blockPos)] = blockInstance;
+  }
+
+  setWater(pos: Vec3, metadata = 0) {
+    this.setBlock(pos, this.blocksByName.water.id, metadata);
+  }
+
+  setStone(pos: Vec3) {
+    this.setBlock(pos, this.blocksByName.stone.id, 0);
+  }
+
+  setIce(pos: Vec3) {
+    this.setBlock(pos, this.blocksByName.ice.id, 0);
+  }
+
+  clearOverrides() {
+    for (const key of Object.keys(this.overrideBlocks)) {
+      delete this.overrideBlocks[key];
+    }
+  }
+
+  getBlock(pos: Vec3): PBlock | null {
+    const blockPos = pos.floored();
+    const override = this.overrideBlocks[this.keyFor(blockPos)];
+    if (override) {
+      return override;
+    }
+
+    const type = blockPos.y < this.floorY ? this.blocksByName.stone.id : this.blocksByName.air.id;
+    const blockInstance = new this.Block(type, 0, 0);
+    blockInstance.position = blockPos;
+    return blockInstance;
+  }
+
+  private keyFor(pos: Vec3) {
+    return `${pos.x},${pos.y},${pos.z}`;
+  }
+}
+
+export function createBoatTestWorld(version: string, floorY: number) {
+  const { mcData, Block } = loadMcData(version);
+  return new BoatTestWorld(mcData.blocksByName, Block, floorY);
+}
+
+export function createBoatRig(options: {
+  version: string;
+  position: Vec3;
+  floorY?: number;
+}) {
+  const { version, position } = options;
+  const floorY = options.floorY ?? Math.floor(position.y) - 1;
+  const { mcData } = loadMcData(version);
+
+  const physics = new BoatPhysics(mcData);
+  const boatEntityType = mcData.entitiesByName.boat;
+  const boatState = BoatState.CREATE_FROM_ENTITY(physics, {
+    position: position.clone(),
+    velocity: new Vec3(0, 0, 0),
+    yaw: 0,
+    pitch: 0,
+    height: 0.5625,
+    width: 1.375,
+    onGround: false,
+    name: "boat",
+  } as Entity);
+  boatState.control = ControlStateHandler.DEFAULT();
+
+  const boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(physics, boatState, boatEntityType);
+  const world = createBoatTestWorld(version, floorY);
+
+  return {
+    mcData,
+    physics,
+    boatState,
+    boatCtx,
+    world,
+  };
+}
+
+export function simulateBoatTick(rig: ReturnType<typeof createBoatRig>) {
+  rig.physics.simulate(rig.boatCtx, rig.world);
+}
+
+export function fillWaterColumn(world: BoatTestWorld, x: number, z: number, fromY: number, toY: number, metadata = 0) {
+  for (let y = fromY; y <= toY; y++) {
+    world.setWater(new Vec3(x, y, z), metadata);
+  }
 }

--- a/tests/unit/boat/movement.test.ts
+++ b/tests/unit/boat/movement.test.ts
@@ -179,6 +179,25 @@ describe("BoatPhysics collisions and world readiness", () => {
     expect(rig.boatState.age).toBe(before.age);
   });
 
+  it("does not require the extra top readiness layer above boat bounds", () => {
+    const rig = setupWaterBoat();
+    const before = rig.boatState.clone();
+    const originalGetBlock = rig.world.getBlock.bind(rig.world);
+    const extraTopY = Math.ceil(boatY + rig.boatState.height) + 1;
+
+    rig.world.getBlock = (pos: Vec3) => {
+      if (pos.y === extraTopY) return null;
+      return originalGetBlock(pos);
+    };
+
+    rig.boatState.control.forward = true;
+    simulateBoatTick(rig);
+
+    expect(rig.boatState.worldReady).toBe(true);
+    expect(rig.boatState.age).toBe(before.age + 1);
+    expect(rig.boatState.pos.z).toBeLessThan(before.pos.z);
+  });
+
   it("clone does not share mutable Vec3 or controls", () => {
     const rig = createBoatRig({ version, position: new Vec3(1, 2, 3), floorY: 0 });
     const clone = rig.boatState.clone();

--- a/tests/unit/boat/movement.test.ts
+++ b/tests/unit/boat/movement.test.ts
@@ -1,0 +1,226 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { BoatStatus } from "../../../src/physics/states/boatState";
+import {
+  createBoatRig,
+  fillWaterColumn,
+  simulateBoatTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const waterSurfaceY = 64;
+const boatY = waterSurfaceY - 0.4;
+
+function fillWaterPool(world: ReturnType<typeof createBoatRig>["world"], fromZ: number, toZ: number) {
+  for (let x = -1; x <= 1; x++) {
+    for (let z = fromZ; z <= toZ; z++) {
+      fillWaterColumn(world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    }
+  }
+}
+
+function setupWaterBoat() {
+  const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+  fillWaterPool(rig.world, -1, 1);
+  return rig;
+}
+
+describe("BoatPhysics movement", () => {
+  it("keeps a stationary boat stable on calm water", () => {
+    const rig = setupWaterBoat();
+    for (let i = 0; i < 20; i++) {
+      simulateBoatTick(rig);
+    }
+    expect(Math.abs(rig.boatState.vel.x)).toBeLessThan(0.01);
+    expect(Math.abs(rig.boatState.vel.z)).toBeLessThan(0.01);
+    expect(rig.boatState.pos.y).toBeCloseTo(boatY, 0);
+  });
+
+  it("accelerates forward over the first three ticks", () => {
+    const rig = setupWaterBoat();
+    rig.boatState.control.forward = true;
+
+    const positions: Array<{ x: number; z: number }> = [];
+    for (let i = 0; i < 3; i++) {
+      simulateBoatTick(rig);
+      positions.push({ x: rig.boatState.pos.x, z: rig.boatState.pos.z });
+    }
+
+    expect(positions[2].z).toBeLessThan(positions[1].z);
+    expect(positions[1].z).toBeLessThan(positions[0].z);
+    expect(positions[0].z).toBeLessThan(0);
+  });
+
+  it("moves backward slower than forward", () => {
+    const forwardRig = setupWaterBoat();
+    forwardRig.boatState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateBoatTick(forwardRig);
+    const forwardDistance = Math.hypot(forwardRig.boatState.pos.x, forwardRig.boatState.pos.z);
+
+    const backRig = setupWaterBoat();
+    backRig.boatState.control.back = true;
+    for (let i = 0; i < 10; i++) simulateBoatTick(backRig);
+    const backDistance = Math.hypot(backRig.boatState.pos.x, backRig.boatState.pos.z);
+
+    expect(forwardDistance).toBeGreaterThan(backDistance * 2);
+  });
+
+  it("turns left and right with opposite yaw deltas", () => {
+    const leftRig = setupWaterBoat();
+    leftRig.boatState.control.left = true;
+    simulateBoatTick(leftRig);
+    const leftYaw = leftRig.boatState.yaw;
+
+    const rightRig = setupWaterBoat();
+    rightRig.boatState.control.right = true;
+    simulateBoatTick(rightRig);
+    const rightYaw = rightRig.boatState.yaw;
+
+    expect(leftYaw).toBeGreaterThan(0);
+    expect(rightYaw).toBeLessThan(0);
+    expect(leftYaw).toBeCloseTo(-rightYaw, 5);
+  });
+
+  it("forward + left follows an arc", () => {
+    const rig = setupWaterBoat();
+    rig.boatState.control.forward = true;
+    rig.boatState.control.left = true;
+    const startYaw = rig.boatState.yaw;
+    simulateBoatTick(rig);
+    expect(rig.boatState.yaw).toBeGreaterThan(startYaw);
+    expect(rig.boatState.pos.z).toBeLessThan(0);
+    expect(Math.abs(rig.boatState.pos.x)).toBeGreaterThan(0);
+  });
+
+  it("coasts after controls are released", () => {
+    const rig = setupWaterBoat();
+    rig.boatState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateBoatTick(rig);
+    const speedAfterInput = Math.hypot(rig.boatState.vel.x, rig.boatState.vel.z);
+    rig.boatState.control.forward = false;
+    rig.boatState.control.back = false;
+    rig.boatState.control.left = false;
+    rig.boatState.control.right = false;
+    simulateBoatTick(rig);
+    const speedAfterRelease = Math.hypot(rig.boatState.vel.x, rig.boatState.vel.z);
+    expect(speedAfterRelease).toBeGreaterThan(0);
+    expect(speedAfterRelease).toBeLessThan(speedAfterInput);
+  });
+});
+
+describe("BoatPhysics collisions and world readiness", () => {
+  it("settles into water when falling from air", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY + 3, 0), floorY: waterSurfaceY - 2 });
+    fillWaterPool(rig.world, -1, 1);
+
+    for (let i = 0; i < 40; i++) {
+      simulateBoatTick(rig);
+    }
+
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+    expect(rig.boatState.pos.y).toBeLessThan(waterSurfaceY);
+    expect(rig.boatState.pos.y).toBeGreaterThan(waterSurfaceY - 1);
+    expect(Math.abs(rig.boatState.vel.y)).toBeLessThan(0.05);
+  });
+
+  it("stops at a shore collision", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    fillWaterPool(rig.world, -2, 0);
+    for (let x = -2; x <= 2; x++) {
+      rig.world.setStone(new Vec3(x, waterSurfaceY - 1, -2));
+      rig.world.setStone(new Vec3(x, waterSurfaceY, -2));
+      rig.world.setStone(new Vec3(x, waterSurfaceY + 1, -2));
+    }
+
+    rig.boatState.control.forward = true;
+    for (let i = 0; i < 30; i++) simulateBoatTick(rig);
+
+    expect(rig.boatState.pos.z).toBeGreaterThan(-2);
+    expect(rig.boatState.isCollidedHorizontally).toBe(true);
+    expect(Math.abs(rig.boatState.vel.z)).toBeLessThan(0.001);
+  });
+
+  it("slides faster on ice than on stone", () => {
+    const stoneRig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY, 0), floorY: waterSurfaceY - 1 });
+    stoneRig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
+    stoneRig.boatState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateBoatTick(stoneRig);
+    const stoneDistance = Math.hypot(stoneRig.boatState.pos.x, stoneRig.boatState.pos.z);
+
+    const iceRig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY, 0), floorY: waterSurfaceY - 1 });
+    iceRig.world.setIce(new Vec3(0, waterSurfaceY - 1, 0));
+    iceRig.boatState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateBoatTick(iceRig);
+    const iceDistance = Math.hypot(iceRig.boatState.pos.x, iceRig.boatState.pos.z);
+
+    expect(iceDistance).toBeGreaterThan(stoneDistance);
+  });
+
+  it("does not mutate state when a required block is unloaded", () => {
+    const rig = setupWaterBoat();
+    const before = rig.boatState.clone();
+    const originalGetBlock = rig.world.getBlock.bind(rig.world);
+    rig.world.getBlock = (pos: Vec3) => {
+      if (pos.x === 0 && pos.z === 0 && pos.y === waterSurfaceY - 1) return null;
+      return originalGetBlock(pos);
+    };
+
+    simulateBoatTick(rig);
+    expect(rig.boatState.worldReady).toBe(false);
+    expect(rig.boatState.pos.x).toBe(before.pos.x);
+    expect(rig.boatState.pos.y).toBe(before.pos.y);
+    expect(rig.boatState.pos.z).toBe(before.pos.z);
+    expect(rig.boatState.vel.x).toBe(before.vel.x);
+    expect(rig.boatState.vel.y).toBe(before.vel.y);
+    expect(rig.boatState.vel.z).toBe(before.vel.z);
+    expect(rig.boatState.yaw).toBe(before.yaw);
+    expect(rig.boatState.status).toBe(before.status);
+    expect(rig.boatState.age).toBe(before.age);
+  });
+
+  it("clone does not share mutable Vec3 or controls", () => {
+    const rig = createBoatRig({ version, position: new Vec3(1, 2, 3), floorY: 0 });
+    const clone = rig.boatState.clone();
+    clone.pos.x = 99;
+    clone.vel.z = 88;
+    clone.control.forward = true;
+    expect(rig.boatState.pos.x).toBe(1);
+    expect(rig.boatState.vel.z).toBe(0);
+    expect(rig.boatState.control.forward).toBe(false);
+  });
+});
+
+describe("BoatPhysics paddles", () => {
+  it("maps forward to both paddles", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.forward = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(true);
+    expect(paddles.rightPaddle).toBe(true);
+  });
+
+  it("does not activate paddles when moving backward", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.back = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(false);
+    expect(paddles.rightPaddle).toBe(false);
+  });
+
+  it("maps right-only input to left paddle", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.right = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(true);
+    expect(paddles.rightPaddle).toBe(false);
+  });
+
+  it("maps left-only input to right paddle", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, 64, 0) });
+    rig.boatState.control.left = true;
+    const paddles = rig.physics.getPaddleState(rig.boatState);
+    expect(paddles.leftPaddle).toBe(false);
+    expect(paddles.rightPaddle).toBe(true);
+  });
+});

--- a/tests/unit/boat/multiversion.test.ts
+++ b/tests/unit/boat/multiversion.test.ts
@@ -18,7 +18,7 @@ const versions = [
   { version: "1.11.2", entityNames: ["boat"] },
   { version: "1.17.1", entityNames: ["boat"] },
   { version: "1.20.4", entityNames: ["boat", "chest_boat"] },
-  { version: "1.21.2", entityNames: ["boat", "chest_boat"] },
+  { version: "1.21.1", entityNames: ["boat", "chest_boat"] },
   { version: "1.21.3", entityNames: ["oak_boat", "oak_chest_boat", "bamboo_raft"] },
   { version: "1.21.11", entityNames: ["oak_boat", "oak_chest_boat", "bamboo_raft"] },
 ];
@@ -163,13 +163,17 @@ describe("BoatPhysics multiversion compatibility", () => {
 
           it("turns left and right with opposite yaw deltas", () => {
             const leftRig = setupWaterBoat(version, entityName);
+            const leftStartYaw = leftRig.boatState.yaw;
             leftRig.boatState.control.left = true;
             simulateBoatTick(leftRig);
 
             const rightRig = setupWaterBoat(version, entityName);
+            const rightStartYaw = rightRig.boatState.yaw;
             rightRig.boatState.control.right = true;
             simulateBoatTick(rightRig);
 
+            expect(leftRig.boatState.yaw).toBeGreaterThan(leftStartYaw);
+            expect(rightRig.boatState.yaw).toBeLessThan(rightStartYaw);
             expect(leftRig.boatState.yaw).toBeGreaterThan(0);
             expect(rightRig.boatState.yaw).toBeLessThan(0);
             expect(leftRig.boatState.yaw).toBeCloseTo(-rightRig.boatState.yaw, 5);

--- a/tests/unit/boat/multiversion.test.ts
+++ b/tests/unit/boat/multiversion.test.ts
@@ -20,8 +20,19 @@ const versions = [
   { version: "1.20.4", entityNames: ["boat", "chest_boat"] },
   { version: "1.21.2", entityNames: ["boat", "chest_boat"] },
   { version: "1.21.3", entityNames: ["oak_boat", "oak_chest_boat", "bamboo_raft"] },
-  { version: "1.21.5", entityNames: ["oak_boat", "oak_chest_boat", "bamboo_raft"] },
+  { version: "1.21.11", entityNames: ["oak_boat", "oak_chest_boat", "bamboo_raft"] },
 ];
+
+function expectBoatPhysicsContext(rig: ReturnType<typeof createBoatRig>) {
+  expect(rig.boatCtx.stepHeight).toBe(0);
+  expect(rig.boatCtx.useControls).toBe(false);
+  expect(rig.boatCtx.gravity).toBe(0.04);
+  expect(rig.boatCtx.airdrag).toBe(1);
+  expect(rig.boatCtx.collisionBehavior).toEqual({
+    blockEffects: false,
+    affectedAfterCollision: true,
+  });
+}
 
 function fillWaterPool(world: BoatTestWorld, fromZ: number, toZ: number) {
   for (let x = -1; x <= 1; x++) {
@@ -58,6 +69,33 @@ describe("BoatPhysics multiversion compatibility", () => {
             expect(rig.entityDescriptor).toBe(rig.mcData.entitiesByName[entityName]);
             expect(rig.boatState.height).toBe(rig.entityDescriptor.height);
             expect(rig.boatState.halfWidth * 2).toBe(rig.entityDescriptor.width);
+          });
+
+          it("uses boat vehicle physics context instead of living-entity defaults", () => {
+            const rig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, boatY, 0),
+            });
+            expectBoatPhysicsContext(rig);
+          });
+
+          it("does not step up or blow through a single-block land wall immediately", () => {
+            const rig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY, 0),
+              floorY: waterSurfaceY - 1,
+            });
+            rig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
+            rig.world.setStone(new Vec3(0, waterSurfaceY, -1));
+            rig.boatState.control.forward = true;
+
+            for (let i = 0; i < 8; i++) simulateBoatTick(rig);
+
+            expect(rig.boatCtx.stepHeight).toBe(0);
+            expect(rig.boatState.pos.z).toBeGreaterThan(-1);
+            expect(rig.boatState.pos.y).toBeLessThan(waterSurfaceY + 0.5);
           });
 
           it("detects water, land, and air status", () => {
@@ -234,5 +272,17 @@ describe("BoatPhysics entity descriptor resolution", () => {
     expect(() => resolveBoatEntityDescriptor(mcData, "boat", "1.21.3")).toThrow(
       'Boat entity descriptor "boat" not found for Minecraft 1.21.3',
     );
+  });
+
+  it("applies boat vehicle context for 1.11.2 even when boat id overlaps mobData", () => {
+    const { mcData } = loadMcData("1.11.2");
+    const boat = mcData.entitiesByName.boat;
+    expect(mcData.mobs[boat.id]).toBeTruthy();
+    const rig = createBoatRig({
+      version: "1.11.2",
+      entityName: "boat",
+      position: new Vec3(0, boatY, 0),
+    });
+    expectBoatPhysicsContext(rig);
   });
 });

--- a/tests/unit/boat/multiversion.test.ts
+++ b/tests/unit/boat/multiversion.test.ts
@@ -1,0 +1,238 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { BoatStatus } from "../../../src/physics/states/boatState";
+import {
+  BoatTestWorld,
+  createBoatRig,
+  fillWaterColumn,
+  loadMcData,
+  resolveBoatEntityDescriptor,
+  simulateBoatTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const waterSurfaceY = 64;
+const boatY = waterSurfaceY - 0.4;
+
+const versions = [
+  { version: "1.11.2", entityNames: ["boat"] },
+  { version: "1.17.1", entityNames: ["boat"] },
+  { version: "1.20.4", entityNames: ["boat", "chest_boat"] },
+  { version: "1.21.2", entityNames: ["boat", "chest_boat"] },
+  { version: "1.21.3", entityNames: ["oak_boat", "oak_chest_boat", "bamboo_raft"] },
+  { version: "1.21.5", entityNames: ["oak_boat", "oak_chest_boat", "bamboo_raft"] },
+];
+
+function fillWaterPool(world: BoatTestWorld, fromZ: number, toZ: number) {
+  for (let x = -1; x <= 1; x++) {
+    for (let z = fromZ; z <= toZ; z++) {
+      fillWaterColumn(world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    }
+  }
+}
+
+function setupWaterBoat(version: string, entityName: string) {
+  const rig = createBoatRig({
+    version,
+    entityName,
+    position: new Vec3(0, boatY, 0),
+    floorY: waterSurfaceY - 2,
+  });
+  fillWaterPool(rig.world, -1, 1);
+  return rig;
+}
+
+describe("BoatPhysics multiversion compatibility", () => {
+  for (const { version, entityNames } of versions) {
+    describe(version, () => {
+      for (const entityName of entityNames) {
+        describe(entityName, () => {
+          it("resolves the requested entity descriptor and uses its dimensions", () => {
+            const rig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, boatY, 0),
+            });
+
+            expect(rig.entityName).toBe(entityName);
+            expect(rig.entityDescriptor).toBe(rig.mcData.entitiesByName[entityName]);
+            expect(rig.boatState.height).toBe(rig.entityDescriptor.height);
+            expect(rig.boatState.halfWidth * 2).toBe(rig.entityDescriptor.width);
+          });
+
+          it("detects water, land, and air status", () => {
+            const waterRig = setupWaterBoat(version, entityName);
+            simulateBoatTick(waterRig);
+            expect(waterRig.boatState.status).toBe(BoatStatus.IN_WATER);
+
+            const landRig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY, 0),
+              floorY: waterSurfaceY - 1,
+            });
+            landRig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
+            simulateBoatTick(landRig);
+            expect(landRig.boatState.status).toBe(BoatStatus.ON_LAND);
+
+            const airRig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY + 5, 0),
+              floorY: waterSurfaceY - 1,
+            });
+            simulateBoatTick(airRig);
+            expect(airRig.boatState.status).toBe(BoatStatus.IN_AIR);
+          });
+
+          it("keeps position, velocity, yaw, and status finite after repeated ticks", () => {
+            const rig = setupWaterBoat(version, entityName);
+            for (let i = 0; i < 20; i++) {
+              simulateBoatTick(rig);
+              expect(Number.isFinite(rig.boatState.pos.x)).toBe(true);
+              expect(Number.isFinite(rig.boatState.pos.y)).toBe(true);
+              expect(Number.isFinite(rig.boatState.pos.z)).toBe(true);
+              expect(Number.isFinite(rig.boatState.vel.x)).toBe(true);
+              expect(Number.isFinite(rig.boatState.vel.y)).toBe(true);
+              expect(Number.isFinite(rig.boatState.vel.z)).toBe(true);
+              expect(Number.isFinite(rig.boatState.yaw)).toBe(true);
+              expect(Object.values(BoatStatus)).toContain(rig.boatState.status);
+            }
+          });
+
+          it("moves forward under forward input", () => {
+            const rig = setupWaterBoat(version, entityName);
+            rig.boatState.control.forward = true;
+            simulateBoatTick(rig);
+            expect(rig.boatState.pos.z).toBeLessThan(0);
+          });
+
+          it("turns left and right with opposite yaw deltas", () => {
+            const leftRig = setupWaterBoat(version, entityName);
+            leftRig.boatState.control.left = true;
+            simulateBoatTick(leftRig);
+
+            const rightRig = setupWaterBoat(version, entityName);
+            rightRig.boatState.control.right = true;
+            simulateBoatTick(rightRig);
+
+            expect(leftRig.boatState.yaw).toBeGreaterThan(0);
+            expect(rightRig.boatState.yaw).toBeLessThan(0);
+            expect(leftRig.boatState.yaw).toBeCloseTo(-rightRig.boatState.yaw, 5);
+          });
+
+          it("slides faster on ice than on stone", () => {
+            const stoneRig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY, 0),
+              floorY: waterSurfaceY - 1,
+            });
+            stoneRig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
+            stoneRig.boatState.control.forward = true;
+            for (let i = 0; i < 5; i++) simulateBoatTick(stoneRig);
+            const stoneDistance = Math.hypot(stoneRig.boatState.pos.x, stoneRig.boatState.pos.z);
+
+            const iceRig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY, 0),
+              floorY: waterSurfaceY - 1,
+            });
+            iceRig.world.setIce(new Vec3(0, waterSurfaceY - 1, 0));
+            iceRig.boatState.control.forward = true;
+            for (let i = 0; i < 5; i++) simulateBoatTick(iceRig);
+            const iceDistance = Math.hypot(iceRig.boatState.pos.x, iceRig.boatState.pos.z);
+
+            expect(iceDistance).toBeGreaterThan(stoneDistance);
+          });
+
+          it("stops at a shore collision", () => {
+            const rig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, boatY, 0),
+              floorY: waterSurfaceY - 2,
+            });
+            fillWaterPool(rig.world, -2, 0);
+            for (let x = -2; x <= 2; x++) {
+              rig.world.setStone(new Vec3(x, waterSurfaceY - 1, -2));
+              rig.world.setStone(new Vec3(x, waterSurfaceY, -2));
+              rig.world.setStone(new Vec3(x, waterSurfaceY + 1, -2));
+            }
+
+            rig.boatState.control.forward = true;
+            for (let i = 0; i < 30; i++) simulateBoatTick(rig);
+
+            expect(rig.boatState.pos.z).toBeGreaterThan(-2);
+            expect(rig.boatState.isCollidedHorizontally).toBe(true);
+            expect(Math.abs(rig.boatState.vel.z)).toBeLessThan(0.001);
+          });
+
+          it("leaves simulation state unchanged when a required block is unloaded", () => {
+            const rig = setupWaterBoat(version, entityName);
+            const before = rig.boatState.clone();
+            const originalGetBlock = rig.world.getBlock.bind(rig.world);
+            rig.world.getBlock = (pos: Vec3) => {
+              if (pos.x === 0 && pos.z === 0 && pos.y === waterSurfaceY - 1) return null;
+              return originalGetBlock(pos);
+            };
+
+            simulateBoatTick(rig);
+            expect(rig.boatState.worldReady).toBe(false);
+            expect(rig.boatState.pos.x).toBe(before.pos.x);
+            expect(rig.boatState.pos.y).toBe(before.pos.y);
+            expect(rig.boatState.pos.z).toBe(before.pos.z);
+            expect(rig.boatState.vel.x).toBe(before.vel.x);
+            expect(rig.boatState.vel.y).toBe(before.vel.y);
+            expect(rig.boatState.vel.z).toBe(before.vel.z);
+            expect(rig.boatState.yaw).toBe(before.yaw);
+            expect(rig.boatState.status).toBe(before.status);
+            expect(rig.boatState.age).toBe(before.age);
+          });
+
+          it("maps paddle state from forward and turn controls", () => {
+            const forwardRig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY, 0),
+            });
+            forwardRig.boatState.control.forward = true;
+            const forwardPaddles = forwardRig.physics.getPaddleState(forwardRig.boatState);
+            expect(forwardPaddles.leftPaddle).toBe(true);
+            expect(forwardPaddles.rightPaddle).toBe(true);
+
+            const rightRig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY, 0),
+            });
+            rightRig.boatState.control.right = true;
+            const rightPaddles = rightRig.physics.getPaddleState(rightRig.boatState);
+            expect(rightPaddles.leftPaddle).toBe(true);
+            expect(rightPaddles.rightPaddle).toBe(false);
+
+            const leftRig = createBoatRig({
+              version,
+              entityName,
+              position: new Vec3(0, waterSurfaceY, 0),
+            });
+            leftRig.boatState.control.left = true;
+            const leftPaddles = leftRig.physics.getPaddleState(leftRig.boatState);
+            expect(leftPaddles.leftPaddle).toBe(false);
+            expect(leftPaddles.rightPaddle).toBe(true);
+          });
+        });
+      }
+    });
+  }
+});
+
+describe("BoatPhysics entity descriptor resolution", () => {
+  it("throws a descriptive error when the requested entity name is missing", () => {
+    const { mcData } = loadMcData("1.21.3");
+    expect(() => resolveBoatEntityDescriptor(mcData, "boat", "1.21.3")).toThrow(
+      'Boat entity descriptor "boat" not found for Minecraft 1.21.3',
+    );
+  });
+});

--- a/tests/unit/boat/multiversion.test.ts
+++ b/tests/unit/boat/multiversion.test.ts
@@ -42,6 +42,30 @@ function fillWaterPool(world: BoatTestWorld, fromZ: number, toZ: number) {
   }
 }
 
+function setupSingleBlockLandWallRig(version: string, entityName: string) {
+  const landY = 64;
+  const rig = createBoatRig({
+    version,
+    entityName,
+    position: new Vec3(0, landY, 0),
+    floorY: landY,
+  });
+  for (let x = -2; x <= 2; x++) {
+    rig.world.setStone(new Vec3(x, landY, -2));
+  }
+  return rig;
+}
+
+function simulateSingleBlockLandWallApproach(rig: ReturnType<typeof createBoatRig>, ticks = 8) {
+  rig.boatState.control.forward = true;
+  let maxY = rig.boatState.pos.y;
+  for (let i = 0; i < ticks; i++) {
+    simulateBoatTick(rig);
+    maxY = Math.max(maxY, rig.boatState.pos.y);
+  }
+  return maxY;
+}
+
 function setupWaterBoat(version: string, entityName: string) {
   const rig = createBoatRig({
     version,
@@ -80,22 +104,14 @@ describe("BoatPhysics multiversion compatibility", () => {
             expectBoatPhysicsContext(rig);
           });
 
-          it("does not step up or blow through a single-block land wall immediately", () => {
-            const rig = createBoatRig({
-              version,
-              entityName,
-              position: new Vec3(0, waterSurfaceY, 0),
-              floorY: waterSurfaceY - 1,
-            });
-            rig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
-            rig.world.setStone(new Vec3(0, waterSurfaceY, -1));
-            rig.boatState.control.forward = true;
-
-            for (let i = 0; i < 8; i++) simulateBoatTick(rig);
+          it("does not step up over a single-block land wall", () => {
+            const rig = setupSingleBlockLandWallRig(version, entityName);
+            const maxY = simulateSingleBlockLandWallApproach(rig);
 
             expect(rig.boatCtx.stepHeight).toBe(0);
             expect(rig.boatState.pos.z).toBeGreaterThan(-1);
-            expect(rig.boatState.pos.y).toBeLessThan(waterSurfaceY + 0.5);
+            expect(maxY).toBeLessThan(64.5);
+            expect(rig.boatState.isCollidedHorizontally).toBe(true);
           });
 
           it("detects water, land, and air status", () => {

--- a/tests/unit/boat/settings.test.ts
+++ b/tests/unit/boat/settings.test.ts
@@ -1,0 +1,264 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import type { Entity } from "prismarine-entity";
+import { Vec3 } from "vec3";
+import { BoatState, BoatStatus } from "../../../src/physics/states/boatState";
+import {
+  createBoatRig,
+  fillWaterColumn,
+  loadMcData,
+  simulateBoatTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+function loadBoatSettingsModule() {
+  return require("../../../src/physics/settings/boatSettings");
+}
+
+function loadBoatSettingsJson() {
+  return require("../../../src/physics/info/entity_physics.json");
+}
+
+function loadEPhysicsCtx() {
+  return require("../../../src/physics/settings").EPhysicsCtx;
+}
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const BASELINE_IN_WATER = {
+  pos: { x: 0, y: 63.593703703861685, z: 0 },
+  vel: { x: 0, y: -0.006296296138316393, z: 0 },
+};
+
+const BASELINE_ON_LAND = {
+  pos: { x: 0, y: 63.96000000089407, z: -0.03999999910593033 },
+  vel: { x: 0, y: -0.03999999910593033, z: -0.03999999910593033 },
+};
+
+describe("Boat settings resolution", () => {
+  it("normalizes float32 fields and preserves double fields from default", () => {
+    const { FLOAT32_FIELDS, resolveBoatSettings } = loadBoatSettingsModule();
+    const boatSection = loadBoatSettingsJson().boats;
+    const defaultSettings = boatSection.default;
+    const { mcData } = loadMcData("1.17.1");
+    const resolved = resolveBoatSettings(mcData);
+
+    for (const field of FLOAT32_FIELDS) {
+      expect(resolved[field]).toBe(Math.fround(defaultSettings[field]));
+    }
+
+    const doubleFields = Object.keys(defaultSettings).filter(
+      (key: string) => !FLOAT32_FIELDS.includes(key),
+    );
+
+    for (const field of doubleFields) {
+      expect(resolved[field]).toBe(defaultSettings[field]);
+    }
+
+    expect(resolved).not.toHaveProperty("height");
+    expect(resolved).not.toHaveProperty("width");
+  });
+
+  it("returns default settings for an unknown major version", () => {
+    const { FLOAT32_FIELDS, resolveBoatSettingsFromSection } = loadBoatSettingsModule();
+    const defaultSettings = loadBoatSettingsJson().boats.default;
+    const { mcData } = loadMcData("1.17.1");
+    const fakeMcData = {
+      ...mcData,
+      version: { ...mcData.version, majorVersion: "99.99" },
+    };
+    const resolved = resolveBoatSettingsFromSection(fakeMcData, loadBoatSettingsJson().boats);
+
+    for (const field of FLOAT32_FIELDS) {
+      expect(resolved[field]).toBe(Math.fround(defaultSettings[field]));
+    }
+  });
+
+  it("applies version-specific overrides and normalizes overridden float32 values", () => {
+    const { resolveBoatSettingsFromSection } = loadBoatSettingsModule();
+    const boatSection = loadBoatSettingsJson().boats;
+    const { mcData } = loadMcData("1.17.1");
+    const testSection = {
+      ...boatSection,
+      overrides: [{ versions: ["1.17"], values: { gravity: 0.05 } }],
+    };
+
+    const onTarget = resolveBoatSettingsFromSection(mcData, testSection);
+    expect(onTarget.gravity).toBe(Math.fround(0.05));
+
+    const offTarget = resolveBoatSettingsFromSection(
+      { ...mcData, version: { ...mcData.version, majorVersion: "1.15" } },
+      testSection,
+    );
+    expect(offTarget.gravity).toBe(Math.fround(boatSection.default.gravity));
+  });
+
+  it("lets the last matching override win when multiple entries match", () => {
+    const { resolveBoatSettingsFromSection } = loadBoatSettingsModule();
+    const boatSection = loadBoatSettingsJson().boats;
+    const { mcData } = loadMcData("1.17.1");
+    const testSection = {
+      ...boatSection,
+      overrides: [
+        { versions: ["1.17"], values: { forwardAcceleration: 0.01 } },
+        { versions: ["1.17"], values: { forwardAcceleration: 0.02 } },
+      ],
+    };
+
+    const resolved = resolveBoatSettingsFromSection(mcData, testSection);
+    expect(resolved.forwardAcceleration).toBe(Math.fround(0.02));
+  });
+
+  it("isolates resolved settings from JSON and from each other", () => {
+    const boatSection = loadBoatSettingsJson().boats;
+    const originalGravity = boatSection.default.gravity;
+    const rigA = createBoatRig({ version: "1.17.1", position: new Vec3(0, 64, 0) });
+    const rigB = createBoatRig({ version: "1.17.1", position: new Vec3(0, 64, 0) });
+
+    expect(rigA.boatCtx.boat).toBeDefined();
+    expect(rigB.boatCtx.boat).toBeDefined();
+    rigA.boatCtx.boat!.gravity = 999;
+    expect(rigB.boatCtx.boat!.gravity).not.toBe(999);
+    expect(boatSection.default.gravity).toBe(originalGravity);
+  });
+});
+
+describe("Boat settings simulation parity", () => {
+  const version = "1.17.1";
+  const waterSurfaceY = 64;
+  const boatY = waterSurfaceY - 0.4;
+
+  it("matches baseline IN_WATER tick exactly", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -1; z <= 1; z++) {
+        fillWaterColumn(rig.world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+      }
+    }
+    rig.boatState.status = BoatStatus.IN_WATER;
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.waterLevel = waterSurfaceY;
+    simulateBoatTick(rig);
+
+    expect(rig.boatState.pos.x).toBe(BASELINE_IN_WATER.pos.x);
+    expect(rig.boatState.pos.y).toBe(BASELINE_IN_WATER.pos.y);
+    expect(rig.boatState.pos.z).toBe(BASELINE_IN_WATER.pos.z);
+    expect(rig.boatState.vel.x).toBe(BASELINE_IN_WATER.vel.x);
+    expect(rig.boatState.vel.y).toBe(BASELINE_IN_WATER.vel.y);
+    expect(rig.boatState.vel.z).toBe(BASELINE_IN_WATER.vel.z);
+  });
+
+  it("matches baseline ON_LAND controlled tick exactly", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY, 0), floorY: waterSurfaceY - 1 });
+    rig.boatState.status = BoatStatus.ON_LAND;
+    rig.boatState.previousStatus = BoatStatus.ON_LAND;
+    rig.boatState.landFriction = 0.6;
+    rig.boatState.controllingPlayer = true;
+    rig.boatState.control.forward = true;
+    simulateBoatTick(rig);
+
+    expect(rig.boatState.pos.x).toBe(BASELINE_ON_LAND.pos.x);
+    expect(rig.boatState.pos.y).toBe(BASELINE_ON_LAND.pos.y);
+    expect(rig.boatState.pos.z).toBe(BASELINE_ON_LAND.pos.z);
+    expect(rig.boatState.vel.x).toBe(BASELINE_ON_LAND.vel.x);
+    expect(rig.boatState.vel.y).toBe(BASELINE_ON_LAND.vel.y);
+    expect(rig.boatState.vel.z).toBe(BASELINE_ON_LAND.vel.z);
+  });
+
+  it("simulates boat physics when FROM_ENTITY_STATE has no entityType", () => {
+    const EPhysicsCtx = loadEPhysicsCtx();
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -1; z <= 1; z++) {
+        fillWaterColumn(rig.world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+      }
+    }
+    rig.boatState.status = BoatStatus.IN_WATER;
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.waterLevel = waterSurfaceY;
+
+    const boatCtx = EPhysicsCtx.FROM_ENTITY_STATE(rig.physics, rig.boatState);
+    expect(boatCtx.boat).toBeUndefined();
+
+    rig.physics.simulate(boatCtx, rig.world);
+
+    expect(rig.boatState.pos.y).toBe(BASELINE_IN_WATER.pos.y);
+    expect(rig.boatState.vel.y).toBe(BASELINE_IN_WATER.vel.y);
+  });
+});
+
+describe("Boat dimensions resolution", () => {
+  const cases = [
+    { version: "1.11.2", width: 1.5, height: 0.6 },
+    { version: "1.12.2", width: 1.5, height: 0.6 },
+    { version: "1.13.2", width: 1.375, height: 0.6 },
+    { version: "1.14.4", width: 1.375, height: 0.5625 },
+    { version: "1.21.4", width: 1.375, height: 0.5625 },
+  ];
+
+  for (const { version, width, height } of cases) {
+    it(`resolves boat dimensions for ${version}`, () => {
+      const { resolveBoatDimensions } = loadBoatSettingsModule();
+      const { mcData } = loadMcData(version);
+      const dims = resolveBoatDimensions(mcData);
+      expect(dims.width).toBe(width);
+      expect(dims.height).toBe(height);
+    });
+  }
+
+  it("resolves dimensions by explicit entity name", () => {
+    const { resolveBoatDimensions } = loadBoatSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const fakeMcData = {
+      ...mcData,
+      entitiesByName: {
+        ...mcData.entitiesByName,
+        wide_boat: { name: "wide_boat", width: 2.5, height: 0.8 },
+        narrow_raft: { name: "narrow_raft", width: 1.0, height: 0.4 },
+      },
+    };
+    expect(resolveBoatDimensions(fakeMcData, "wide_boat")).toEqual({ width: 2.5, height: 0.8 });
+    expect(resolveBoatDimensions(fakeMcData, "narrow_raft")).toEqual({ width: 1.0, height: 0.4 });
+  });
+
+  it("uses version-correct dimensions when entity lacks height and width", () => {
+    const rig = createBoatRig({ version: "1.11.2", position: new Vec3(0, 64, 0) });
+    const entity: Partial<Entity> = {
+      position: new Vec3(0, 64, 0),
+      velocity: new Vec3(0, 0, 0),
+      yaw: 0,
+      pitch: 0,
+      onGround: false,
+      name: "boat",
+    };
+    const state = BoatState.CREATE_FROM_ENTITY(rig.physics, entity as Entity);
+    expect(state.height).toBe(0.6);
+    expect(state.halfWidth).toBe(1.5 / 2);
+  });
+
+  it("rejects partially filled entity descriptors and continues the chain", () => {
+    const { resolveBoatDimensions } = loadBoatSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const fakeMcData = {
+      ...mcData,
+      entitiesByName: {
+        ...mcData.entitiesByName,
+        broken_boat: { name: "broken_boat", width: 1.375 },
+      },
+    };
+    const fallback = { width: 9, height: 9 };
+    const dims = resolveBoatDimensions(fakeMcData, "broken_boat", fallback);
+    expect(dims).toEqual({ width: 1.375, height: 0.5625 });
+  });
+
+  it("returns the provided fallback when no boat entities exist", () => {
+    const { resolveBoatDimensions } = loadBoatSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const fakeMcData = {
+      ...mcData,
+      entitiesByName: { player: mcData.entitiesByName.player },
+    };
+    const fallback = { width: 2, height: 1 };
+    const dims = resolveBoatDimensions(fakeMcData, undefined, fallback);
+    expect(dims).toEqual(fallback);
+  });
+});

--- a/tests/unit/boat/status.test.ts
+++ b/tests/unit/boat/status.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { BoatStatus } from "../../../src/physics/states/boatState";
+import {
+  createBoatRig,
+  fillWaterColumn,
+  simulateBoatTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const waterSurfaceY = 64;
+const boatY = waterSurfaceY - 0.4;
+
+describe("BoatPhysics status detection", () => {
+  it("detects IN_WATER on source water", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+  });
+
+  it("detects UNDER_WATER when top is submerged in source water", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY, 0);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_WATER);
+  });
+
+  it("detects UNDER_FLOWING_WATER for falling water above the boat top", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    rig.world.setWater(new Vec3(0, waterSurfaceY, 0), 8);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_FLOWING_WATER);
+  });
+
+  it("normalizes UNDER_WATER to IN_WATER on first tick from air", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY, 0);
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+  });
+
+  it("detects ON_LAND when resting on solid ground", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY, 0), floorY: waterSurfaceY - 1 });
+    rig.world.setStone(new Vec3(0, waterSurfaceY - 1, 0));
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.ON_LAND);
+  });
+
+  it("detects IN_AIR when no water or ground contact", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY + 5, 0), floorY: waterSurfaceY - 1 });
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_AIR);
+  });
+});
+
+describe("BoatPhysics fluid height", () => {
+  it("treats water level 8 as flowing, not source", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, boatY, 0), floorY: waterSurfaceY - 2 });
+    rig.world.setWater(new Vec3(0, waterSurfaceY - 1, 0), 8);
+    simulateBoatTick(rig);
+    expect(Number(rig.world.getBlock(new Vec3(0, waterSurfaceY - 1, 0))!.getProperties().level)).toBe(8);
+    expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+  });
+
+  it("treats steady-state submerged boat in level 1 water as UNDER_FLOWING_WATER", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.9, 0), floorY: waterSurfaceY - 2 });
+    rig.world.setWater(new Vec3(0, waterSurfaceY - 1, 0), 1);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    for (let i = 0; i < 5; i++) {
+      simulateBoatTick(rig);
+    }
+    expect(Number(rig.world.getBlock(new Vec3(0, waterSurfaceY - 1, 0))!.getProperties().level)).toBe(1);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_FLOWING_WATER);
+  });
+
+  it("raises fluid height to 1 when the block above is also water", () => {
+    const rig = createBoatRig({ version, position: new Vec3(0, waterSurfaceY - 0.55, 0), floorY: waterSurfaceY - 2 });
+    fillWaterColumn(rig.world, 0, 0, waterSurfaceY - 1, waterSurfaceY, 0);
+    rig.boatState.previousStatus = BoatStatus.IN_WATER;
+    rig.boatState.status = BoatStatus.IN_WATER;
+    simulateBoatTick(rig);
+    expect(rig.boatState.status).toBe(BoatStatus.UNDER_WATER);
+  });
+});

--- a/tests/unit/boat/waterEntry.test.ts
+++ b/tests/unit/boat/waterEntry.test.ts
@@ -11,31 +11,45 @@ import {
 const waterSurfaceY = 64;
 const waterEntryStartY = 63.885;
 const expectedSnapY = 63.5385;
+const edgeTouchBoatX = 0.3125;
 
-function setupWaterEntryRig(version: string, options?: { obstacleAtCenter?: boolean; edgeObstacle?: boolean }) {
+function fillWaterPool(world: ReturnType<typeof createBoatRig>["world"]) {
+  for (let x = -1; x <= 1; x++) {
+    for (let z = -1; z <= 1; z++) {
+      fillWaterColumn(world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    }
+  }
+}
+
+function setupWaterEntryRig(
+  version: string,
+  options?: {
+    position?: Vec3;
+    obstacleAtCenter?: boolean;
+    edgeObstacle?: boolean;
+    initialVelocityY?: number;
+  },
+) {
+  const position = options?.position ?? new Vec3(0, waterEntryStartY, 0);
   const rig = createBoatRig({
     version,
     entityName: "boat",
-    position: new Vec3(0, waterEntryStartY, 0),
+    position,
     floorY: waterSurfaceY - 2,
   });
 
-  for (let x = -1; x <= 1; x++) {
-    for (let z = -1; z <= 1; z++) {
-      fillWaterColumn(rig.world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
-    }
-  }
+  fillWaterPool(rig.world);
 
   if (options?.obstacleAtCenter) {
     rig.world.setStone(new Vec3(0, waterSurfaceY, 0));
   }
   if (options?.edgeObstacle) {
-    rig.world.setStone(new Vec3(3, waterSurfaceY, 0));
+    rig.world.setStone(new Vec3(1, waterSurfaceY, 0));
   }
 
   rig.boatState.status = BoatStatus.IN_AIR;
   rig.boatState.previousStatus = BoatStatus.IN_AIR;
-  rig.boatState.vel.y = -0.5;
+  rig.boatState.vel.y = options?.initialVelocityY ?? -0.5;
 
   return rig;
 }
@@ -66,10 +80,24 @@ describe("BoatPhysics water-entry reposition", () => {
   });
 
   it("still repositions on 1.21.1 when a solid only edge-touches the target snap AABB", () => {
-    const rig = setupWaterEntryRig("1.21.1", { edgeObstacle: true });
+    const rig = setupWaterEntryRig("1.21.1", {
+      position: new Vec3(edgeTouchBoatX, waterEntryStartY, 0),
+      edgeObstacle: true,
+    });
     simulateWaterEntryTick(rig);
 
     expect(rig.boatState.pos.y).toBeCloseTo(expectedSnapY, 3);
+    expect(rig.boatState.vel.y).toBe(0);
+  });
+
+  it("zeroes vertical velocity on 1.21.1 when the boat is already at the target snap Y", () => {
+    const rig = setupWaterEntryRig("1.21.1", {
+      position: new Vec3(0, expectedSnapY, 0),
+      initialVelocityY: -0.3,
+    });
+    simulateWaterEntryTick(rig);
+
+    expect(rig.boatState.pos.y).toBeCloseTo(expectedSnapY, 5);
     expect(rig.boatState.vel.y).toBe(0);
   });
 });

--- a/tests/unit/boat/waterEntry.test.ts
+++ b/tests/unit/boat/waterEntry.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { BoatStatus } from "../../../src/physics/states/boatState";
+import {
+  createBoatRig,
+  fillWaterColumn,
+  simulateBoatTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const waterSurfaceY = 64;
+const waterEntryStartY = 63.885;
+const expectedSnapY = 63.5385;
+
+function setupWaterEntryRig(version: string, options?: { obstacleAtCenter?: boolean; edgeObstacle?: boolean }) {
+  const rig = createBoatRig({
+    version,
+    entityName: "boat",
+    position: new Vec3(0, waterEntryStartY, 0),
+    floorY: waterSurfaceY - 2,
+  });
+
+  for (let x = -1; x <= 1; x++) {
+    for (let z = -1; z <= 1; z++) {
+      fillWaterColumn(rig.world, x, z, waterSurfaceY - 1, waterSurfaceY - 1, 0);
+    }
+  }
+
+  if (options?.obstacleAtCenter) {
+    rig.world.setStone(new Vec3(0, waterSurfaceY, 0));
+  }
+  if (options?.edgeObstacle) {
+    rig.world.setStone(new Vec3(3, waterSurfaceY, 0));
+  }
+
+  rig.boatState.status = BoatStatus.IN_AIR;
+  rig.boatState.previousStatus = BoatStatus.IN_AIR;
+  rig.boatState.vel.y = -0.5;
+
+  return rig;
+}
+
+function simulateWaterEntryTick(rig: ReturnType<typeof createBoatRig>) {
+  simulateBoatTick(rig);
+  expect(rig.boatState.status).toBe(BoatStatus.IN_WATER);
+}
+
+describe("BoatPhysics water-entry reposition", () => {
+  it("repositions unconditionally on 1.20.4 when a solid intersects the target snap position", () => {
+    const rig = setupWaterEntryRig("1.20.4", { obstacleAtCenter: true });
+    simulateWaterEntryTick(rig);
+
+    expect(rig.physics.supportFeature("boatWaterEntryCollisionGuard")).toBe(false);
+    expect(rig.boatState.pos.y).toBeCloseTo(expectedSnapY, 3);
+    expect(rig.boatState.vel.y).toBe(0);
+  });
+
+  it("blocks reposition on 1.21.1 when a solid intersects the target snap position", () => {
+    const rig = setupWaterEntryRig("1.21.1", { obstacleAtCenter: true });
+    simulateWaterEntryTick(rig);
+
+    expect(rig.physics.supportFeature("boatWaterEntryCollisionGuard")).toBe(true);
+    expect(rig.boatState.pos.y).not.toBeCloseTo(expectedSnapY, 3);
+    expect(rig.boatState.pos.y).toBeLessThan(waterEntryStartY);
+    expect(rig.boatState.vel.y).toBe(-0.5);
+  });
+
+  it("still repositions on 1.21.1 when a solid only edge-touches the target snap AABB", () => {
+    const rig = setupWaterEntryRig("1.21.1", { edgeObstacle: true });
+    simulateWaterEntryTick(rig);
+
+    expect(rig.boatState.pos.y).toBeCloseTo(expectedSnapY, 3);
+    expect(rig.boatState.vel.y).toBe(0);
+  });
+});


### PR DESCRIPTION
Thanks for the review feedback on #56. I split the boat work into a clean,
boat-only branch based on the latest `upstream/master`. Horse physics is not
included here; after this boat PR is merged, I plan to open horse physics as a
separate PR based on the then-current `master`, with its own version matrix and
vanilla references.

## Version scope and data coverage

The implementation follows the post-1.9 vanilla boat model. Automated
entity-backed coverage starts at 1.11.2 because the installed `minecraft-data`
does not provide a usable boat entity descriptor for 1.9–1.10. This PR does not
claim pre-1.9 support.

The automated matrix uses `minecraft-data@3.111.0` and covers:

- 1.11.2: `boat` (including its older `1.5 x 0.6` dimensions)
- 1.17.1: `boat`, plus the complete original boat regression suite
- 1.20.4: `boat`, `chest_boat`
- 1.21.1: `boat`, `chest_boat`
- 1.21.3: `oak_boat`, `oak_chest_boat`, `bamboo_raft`
- 1.21.11: `oak_boat`, `oak_chest_boat`, `bamboo_raft`

There is intentionally no `1.21.2` matrix row. Vanilla changes to
material-specific boat/raft entity registrations in 1.21.2, but
`minecraft-data("1.21.2")` in this package version resolves the 1.21 generic
entity dataset (`boat`, `chest_boat`). The first installed exact dataset after
that registry split is 1.21.3, so presenting a 1.21.2 row as exact coverage would
be misleading.

Every matrix entry resolves the requested real entity descriptor and dimensions;
the test fails explicitly if the requested descriptor is absent. The simulation
therefore does not hardcode the 1.17.1 boat size.

I also moved boat/raft classification ahead of the numeric `mobData` lookup in
`EPhysicsCtx`. This matters on 1.11.2, where the boat entity ID overlaps an entry
in the mob table and previously received living-entity settings
(`stepHeight=1`, `gravity=0.08`). `boat`, `*_boat`, and `*_raft` now receive the
vehicle context (`stepHeight=0`, `gravity=0.04`) before that lookup.

## Vanilla evidence by version boundary

### Early post-1.9 provenance

For the versions older than the linked Mojang-mapped source archive, I checked
the exact vanilla server artifacts and version-specific mappings:

- **1.9.4:** [Mojang server jar](https://piston-data.mojang.com/v1/objects/edbb7b1758af33d365bf835eb9d13de005b1e274/server.jar),
  SHA-1 `edbb7b1758af33d365bf835eb9d13de005b1e274`, mapped with
  [Spigot BuildData `9b100f8`](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/builddata/commits/9b100f8a6f0d86b5fd5f22f65dd6dd9eba6547d3).
- **1.11.2:** [Mojang server jar](https://piston-data.mojang.com/v1/objects/f00c294a1576e03fddcac777c3cf4c7d404c4ba4/server.jar),
  SHA-1 `f00c294a1576e03fddcac777c3cf4c7d404c4ba4`, mapped with
  [Spigot BuildData `8df2731`](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/builddata/commits/8df2731012bb6887630ce7ebd4c7220eabe49a07).

A short normalized excerpt of the mapped/decompiled `EntityBoat` logic in both
versions is:

```text
status: UNDER_WATER / UNDER_FLOWING_WATER / IN_WATER / ON_LAND / IN_AIR
gravity: 0.04
IN_WATER drag: 0.9
UNDER_WATER drag: 0.45, buoyancy: 0.01
UNDER_FLOWING_WATER vertical term: -0.0007
air-to-water Y offset: +0.101
forward acceleration: +0.04; backward: -0.005
```

This establishes the algorithm family at 1.9.4. Automated entity-backed claims
begin later, at 1.11.2, and the exact artifact/mapping pair above makes the older
source result reproducible rather than treating a newer source file as proof for
all versions.

### Exact files for the automated matrix

These are the version-labelled vanilla files used for every automated matrix
version, not just a 1.17.1 file treated as representative of all releases:

- **1.11.2:** the exact Mojang jar and version-specific mapping linked above;
- **1.17.1:** [`Boat.java`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L420-L640);
- **1.20.4:** [`Boat.java`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.20.4/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L422-L642);
- **1.21.1:** [`Boat.java`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L444-L672);
- **1.21.3:** [`AbstractBoat.java`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.3/minecraft/src/net/minecraft/world/entity/vehicle/AbstractBoat.java#L425-L653);
- **1.21.11:** [`AbstractBoat.java`](https://mcsrc.dev/1/1.21.11/net/minecraft/world/entity/vehicle/boat/AbstractBoat.java)
  (`floatBoat` is at source lines 578-628).

For an additional linked early checkpoint, the same model is visible in
[1.14.4 `Boat.java`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.14.4/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L397-L627).

### Stable status, friction, buoyancy, controls, and paddles

The linked sources above show the same five-state decision tree and the same
ordinary movement structure across the matrix:

The status decision is structurally:

```text
underwater result -> UNDER_WATER or UNDER_FLOWING_WATER
otherwise water contact -> IN_WATER
otherwise positive ground friction -> ON_LAND
otherwise -> IN_AIR
```

The same sources show that ground friction is averaged over intersecting block
collision shapes, and that lily pads are excluded. The shared ordinary-movement
constants remain gravity `0.04`, water drag `0.9`, submerged drag `0.45`,
underwater buoyancy `0.01`, flowing-water vertical term `-0.0007`, water-entry
offset `0.101`, forward acceleration `0.04`, and backward acceleration `0.005`.

The flowing-water variable name changes between decompilations, but the behavior
does not: the vertical term is `-0.0007` throughout. I am not presenting that
decompiler naming difference as a version-specific physics change.

For controls and paddles, see
[1.17.1 `Boat#controlBoat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L611-L640)
and
[1.21.2 `AbstractBoat#controlBoat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/vehicle/AbstractBoat.java#L624-L653):

```text
left/right -> opposite rotation deltas
forward -> +0.04; backward -> -0.005
forward -> both paddles; turn-only -> opposite-side paddle
```

Vanilla calls `controlBoat()` only while the boat has a passenger. `BoatPhysics`
models that controlled-rider path, and the Mineflayer integration invokes it only
while the bot controls the boat. Its yaw is stored in radians using Mineflayer's
yaw convention.

### Actual behavior change: water-entry collision guard in 1.21

This is the relevant physics boundary found during the multiversion review.

In 1.20.6 and earlier, air-to-water entry repositions the boat unconditionally:
[1.20.6 `Boat#floatBoat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.20.6/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L573-L611).

```java
this.setPos(this.getX(), this.getWaterLevelAbove() - this.getBbHeight() + 0.101, this.getZ());
```

Starting in 1.21, the same reposition is guarded by `noCollision(...)`:
[1.21 `Boat#floatBoat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L600-L641).

```java
if (this.level().noCollision(this, this.getBoundingBox().move(0.0, f - this.getY(), 0.0))) {
    this.setPos(this.getX(), f, this.getZ());
}
```

The guard remains after the 1.21.2 class split:
[1.21.2 `AbstractBoat#floatBoat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/vehicle/AbstractBoat.java#L581-L622).

The TypeScript implementation represents this boundary with
`boatWaterEntryCollisionGuard` for major version 1.21:

- 1.20.6 and earlier: direct, unconditional Y reposition and vertical-velocity reset;
- 1.21.x: reposition only when the target AABB has no positive-volume solid overlap;
- touching a block exactly at an AABB edge is allowed, matching `noCollision`'s
  block-collision semantics; this implementation checks block collisions only,
  not entities or the world border;
- the Y update is direct (vanilla `setPos` semantics), not collision-clipped movement.

Differential tests cover 1.20.4 and 1.21.1 with the same solid obstacle at the
candidate snap position, plus the edge-touch and already-at-target-Y cases.

### 1.21.2 registry and class split

Vanilla 1.21.1 still registers generic
[`boat` and `chest_boat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/EntityType.java#L214-L242).
Vanilla 1.21.2 registers material-specific types, including
[`bamboo_raft`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/EntityType.java#L232-L235)
and
[`oak_boat` / `oak_chest_boat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/EntityType.java#L635-L646).

At the same boundary, common movement moves to
[`AbstractBoat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/vehicle/AbstractBoat.java#L425-L653).
[`Boat`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/vehicle/Boat.java#L1-L17),
[`Raft`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/vehicle/Raft.java#L1-L17),
and the
[`AbstractChestBoat` variants](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.2/minecraft/src/net/minecraft/world/entity/vehicle/AbstractChestBoat.java#L1-L38)
inherit that movement. Their relevant overrides concern passenger placement, not
the status/friction/buoyancy/control algorithm, so one dimension-driven
`BoatPhysics` implementation is used for boats, chest boats, and rafts.

## Tests and local integration

The multiversion suite asserts, for each listed version/entity pair:

- exact descriptor resolution and dimensions;
- boat vehicle context, including the 1.11.2 numeric-ID overlap guard;
- water, underwater, flowing-water, land, and air status;
- finite repeated simulation and forward/turn behavior;
- ice-versus-stone friction and solid-shore collision;
- no living-entity-style step-up over a one-block land wall;
- unloaded-world atomicity;
- paddle mapping.

Local results on Node 22:

```text
npm run build
PASS

npx mocha --require ts-node/register "tests/unit/boat/**/*.test.ts"
163 passing, 0 failing

npm test
220 passing, 4 failing
```

The four full-suite failures reproduce unchanged on the `upstream/master` base
(`2b52a1e`) and are all in the pre-existing Botcraft dry-sign water-channel
tests for 1.18.2 and 1.21.11. The boat branch introduces no additional
full-suite failure.

I also linked this branch into the local Mineflayer integration and verified
controlled boat movement on a live 1.17.1 server.

No Mineflayer version gate is widened by this library PR. Activating local boat
physics for additional Mineflayer versions remains a separate integration task
with its own packet and entity-name coverage.