### PR TITLE
fix(botcraft): step-up must probe from an unmodified bounding box

### DIFF
--- a/src/physics/engines/botcraft.ts
+++ b/src/physics/engines/botcraft.ts
@@ -1295,7 +1295,7 @@ export class BotcraftPhysics implements IPhysics {
           const adjustedStepUp = this.collideBoundingBox(
             world,
 
-            playerAABB.translateVec(stepOnlyMovement),
+            playerAABB.move(stepOnlyMovement),
             new Vec3(movement.x, 0, movement.z),
           ).add(stepOnlyMovement);
 
@@ -1308,7 +1308,7 @@ export class BotcraftPhysics implements IPhysics {
           newMovement = stepUpMovement.add(
             this.collideBoundingBox(
               world,
-              playerAABB.translateVec(stepUpMovement),
+              playerAABB.move(stepUpMovement),
               new Vec3(0, -stepUpMovement.y + movement.y, 0),
             )
           );

--- a/tests/unit/botcraft/stepUpAgainstWall.test.ts
+++ b/tests/unit/botcraft/stepUpAgainstWall.test.ts
@@ -1,0 +1,249 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { createBotcraftPlayerRig, createFlatWorld, loadMcData } from "../../helpers/unit/botcraftTestSupport";
+
+/**
+ * Entity::collide step-up must never leave the entity embedded in the block it stepped
+ * onto.
+ *
+ * Vanilla (<= 1.20.6) Entity#collide runs its follow-up step-up probes from the
+ * *unmodified* bounding box, because AABB#move returns a new AABB:
+ *
+ *   Vec3 vec35 = collideBoundingBox(this, new Vec3(vec3.x, 0.0, vec3.z), aABB.move(vec34), ...).add(vec34);
+ *   return vec33.add(collideBoundingBox(this, new Vec3(0.0, -vec33.y + vec3.y, 0.0), aABB.move(vec33), ...));
+ *
+ * Scenario: 1-wide corridor, the entity walks diagonally into the side wall while
+ * stepping onto a 0.5-high step. The wall reaches above the entity's head, so the
+ * "step only" probe - which is expanded towards the horizontal movement, i.e. into the
+ * wall column - is clipped by the wall block above the head. That is the branch which
+ * used to corrupt the shared bounding box, dropping the entity 0.2 short of the surface
+ * and leaving it inside the step.
+ */
+
+const GROUND = 60;
+const DIAGONAL_YAW = -20 * (Math.PI / 180);
+
+/**
+ * 1.20.4 / 1.20.5 straddle the version check in applyMovement: below 1.20.5 the step
+ * height is the static `ctx.stepHeight`, from 1.20.5 on it is read from the entity
+ * attribute (falling back to `ctx.stepHeight` when the dataset has no such attribute).
+ */
+const VERSIONS = [
+  "1.8.9", "1.9.4", "1.10.2", "1.11.2", "1.12.2", "1.13.2", "1.14.4", "1.15.2",
+  "1.16.5", "1.17.1", "1.18.2", "1.19.4", "1.20.1", "1.20.4", "1.20.5", "1.20.6",
+  "1.21.1", "1.21.4", "1.21.8", "1.21.11",
+];
+
+/**
+ * The installed minecraft-data only ships a `stepHeight` attribute descriptor from 1.21
+ * on, so the cases that actually put a value in the attribute are driven by the dataset
+ * rather than by a hardcoded version list.
+ */
+function hasStepHeightAttribute(version: string) {
+  const { mcData } = loadMcData(version);
+  return (mcData as any).attributesByName?.stepHeight != null;
+}
+
+function findState(version: string, blockName: string, wanted: Record<string, unknown>) {
+  const { mcData, Block } = loadMcData(version);
+  const def = mcData.blocksByName[blockName] as any;
+  if (!def) return null;
+  const count = (def.maxStateId ?? def.minStateId ?? 0) - (def.minStateId ?? 0);
+  for (let metadata = 0; metadata <= count; metadata++) {
+    const block = new Block(def.id, 0, metadata);
+    const props = block.getProperties() as Record<string, unknown>;
+    if (props.waterlogged === true) continue; // water would take a different movement path
+    if (Object.entries(wanted).every(([key, value]) => props[key] === value)) {
+      return { id: def.id as number, metadata, shapes: block.shapes };
+    }
+  }
+  return null;
+}
+
+/**
+ * Before 1.12 minecraft-data returns the same stair collision shape for every facing,
+ * so a stair scenario cannot be placed deterministically there. Detect that instead of
+ * hardcoding a version cutoff.
+ */
+function stairShapesFollowFacing(version: string) {
+  const north = findState(version, "acacia_stairs", { facing: "north", half: "bottom" });
+  const east = findState(version, "acacia_stairs", { facing: "east", half: "bottom" });
+  if (!north || !east) return false;
+  return JSON.stringify(north.shapes) !== JSON.stringify(east.shapes);
+}
+
+/** Sand walls at x = -1 and x = +1, tall enough to reach above the player's head. */
+function buildWalls(
+  fakeWorld: ReturnType<typeof createFlatWorld>,
+  sandId: number,
+  fromZ: number,
+  toZ: number,
+  baseY: number,
+  height: number,
+) {
+  for (let z = fromZ; z >= toZ; z--) {
+    for (let dy = 0; dy < height; dy++) {
+      fakeWorld.setOverrideBlock(new Vec3(-1, baseY + dy, z), sandId);
+      fakeWorld.setOverrideBlock(new Vec3(1, baseY + dy, z), sandId);
+    }
+  }
+}
+
+function walkDiagonally(
+  version: string,
+  fakeWorld: ReturnType<typeof createFlatWorld>,
+  ticks: number,
+  stepHeightAttribute?: number,
+) {
+  const rig = createBotcraftPlayerRig({
+    version,
+    position: new Vec3(0.5, GROUND, 0.5),
+    groundLevel: GROUND,
+  });
+
+  if (stepHeightAttribute != null) {
+    const key = (rig.physics as any).stepHeightAttribute as string | null;
+    expect(key).not.toBeNull();
+    (rig.playerState as any).attributes[key!] = { value: stepHeightAttribute, modifiers: [] };
+  }
+
+  rig.playerState.look(DIAGONAL_YAW, 0);
+  rig.playerState.control.forward = true;
+
+  const trace: Vec3[] = [];
+  for (let i = 0; i < ticks; i++) {
+    rig.physics.simulate(rig.playerCtx, fakeWorld as any);
+    rig.playerState.apply(rig.fakePlayer);
+    trace.push(rig.playerState.pos.clone());
+  }
+  return trace;
+}
+
+function expectOnlyOnSurfaces(trace: Vec3[], surfaces: number[]) {
+  for (const pos of trace) {
+    const onSurface = surfaces.some((surface) => Math.abs(pos.y - surface) < 1e-6);
+    // compared as an object so a failure prints the offending Y
+    expect({ y: pos.y, onSurface }).toEqual({ y: pos.y, onSurface: true });
+  }
+}
+
+describe("Botcraft step-up against a side wall", () => {
+  for (const version of VERSIONS) {
+    describe(version, () => {
+      it("lands on top of a slab step instead of inside it", () => {
+        const { mcData } = loadMcData(version);
+        const fakeWorld = createFlatWorld(version, GROUND);
+        const sandId = mcData.blocksByName.sand.id;
+        const slab = findState(version, "stone_slab", { type: "bottom" })
+          ?? findState(version, "smooth_stone_slab", { type: "bottom" });
+        expect(slab).not.toBeNull();
+
+        fakeWorld.setOverrideBlock(new Vec3(0, GROUND, -2), slab!.id, slab!.metadata);
+        buildWalls(fakeWorld, sandId, 1, -4, GROUND, 4);
+
+        const trace = walkDiagonally(version, fakeWorld, 16);
+        fakeWorld.clearOverrides();
+
+        expectOnlyOnSurfaces(trace, [GROUND, GROUND + 0.5]);
+
+        const last = trace[trace.length - 1];
+        expect(last.y).toBeCloseTo(GROUND + 0.5, 6);
+        expect(last.z).toBeLessThan(-1);
+      });
+
+      it("keeps climbing a staircase while pressed against the wall", function () {
+        if (!stairShapesFollowFacing(version)) {
+          // minecraft-data has no per-facing stair collision shapes for this version
+          this.skip();
+        }
+
+        const { mcData } = loadMcData(version);
+        const fakeWorld = createFlatWorld(version, GROUND);
+        const sandId = mcData.blocksByName.sand.id;
+        const stairs = findState(version, "acacia_stairs", { facing: "north", half: "bottom" })!;
+
+        const steps = 6;
+        for (let i = 0; i < steps; i++) {
+          const y = GROUND + i;
+          const z = -1 - i;
+          fakeWorld.setOverrideBlock(new Vec3(0, y, z), stairs.id, stairs.metadata);
+          for (let fill = GROUND; fill < y; fill++) {
+            fakeWorld.setOverrideBlock(new Vec3(0, fill, z), sandId);
+          }
+          for (let dy = 0; dy < 4; dy++) {
+            fakeWorld.setOverrideBlock(new Vec3(-1, y + dy, z), sandId);
+            fakeWorld.setOverrideBlock(new Vec3(1, y + dy, z), sandId);
+          }
+        }
+        buildWalls(fakeWorld, sandId, 1, 0, GROUND, 4);
+
+        const trace = walkDiagonally(version, fakeWorld, 24);
+        fakeWorld.clearOverrides();
+
+        // stair surfaces are multiples of 0.5 - never a step-up remainder such as 0.3
+        for (const pos of trace) {
+          expect(Math.abs((pos.y * 2) % 1)).toBeLessThan(1e-6);
+        }
+
+        // the climb must not stall: height and distance keep increasing
+        const last = trace[trace.length - 1];
+        expect(last.y).toBeGreaterThanOrEqual(GROUND + 2);
+        expect(last.z).toBeLessThan(-2);
+      });
+
+      it("steps onto a full block when the step-height attribute allows it", function () {
+        if (!hasStepHeightAttribute(version)) {
+          // this dataset has no step-height attribute descriptor, so the attribute-aware
+          // branch falls back to the static step height, which the cases above cover
+          this.skip();
+        }
+
+        {
+          const { mcData } = loadMcData(version);
+          const fakeWorld = createFlatWorld(version, GROUND);
+          const sandId = mcData.blocksByName.sand.id;
+
+          fakeWorld.setOverrideBlock(new Vec3(0, GROUND, -2), sandId);
+          buildWalls(fakeWorld, sandId, 1, -4, GROUND, 4);
+
+          const trace = walkDiagonally(version, fakeWorld, 16, 1.0);
+          fakeWorld.clearOverrides();
+
+          // never inside the block: only the floor or its top face
+          expectOnlyOnSurfaces(trace, [GROUND, GROUND + 1]);
+
+          const last = trace[trace.length - 1];
+          expect(last.y).toBeCloseTo(GROUND + 1, 6);
+          expect(last.z).toBeLessThan(-1);
+        }
+      });
+
+      it("honours a step-height attribute below the step and refuses to climb", function () {
+        if (!hasStepHeightAttribute(version)) this.skip();
+
+        {
+          // 0.4 < the 0.5 slab: the entity must stop at the slab face, never step up and
+          // never end up inside it. This is what proves the attribute is really read
+          // instead of the static 0.6 default.
+          const { mcData } = loadMcData(version);
+          const fakeWorld = createFlatWorld(version, GROUND);
+          const sandId = mcData.blocksByName.sand.id;
+          const slab = findState(version, "stone_slab", { type: "bottom" })!;
+
+          fakeWorld.setOverrideBlock(new Vec3(0, GROUND, -2), slab.id, slab.metadata);
+          buildWalls(fakeWorld, sandId, 1, -4, GROUND, 4);
+
+          const trace = walkDiagonally(version, fakeWorld, 16, 0.4);
+          fakeWorld.clearOverrides();
+
+          expectOnlyOnSurfaces(trace, [GROUND]);
+
+          const last = trace[trace.length - 1];
+          expect(last.y).toBeCloseTo(GROUND, 6);
+          expect(last.z).toBeGreaterThan(-1); // blocked by the slab's front face
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`BotcraftPhysics.applyMovement` (the `Entity::collide` port) mutates the player's bounding
box in the middle of the step-up probes, so the final "drop back down onto the surface"
probe starts from the wrong height. The player ends up **inside** the block it stepped onto
instead of on top of it, and then gets stuck there permanently.

Two calls use `AABB#translateVec`, which mutates in place and returns `this`
(`node-aabb`), where vanilla uses `AABB#move`, which returns a new box. `node-aabb` already
exposes `move()` with the vanilla (copying) semantics, so the fix is a two-line change.

## Reproduction

1-wide corridor, side walls taller than the player, a 0.5-high step (slab or stairs).
Walk diagonally into the side wall while stepping up.

Tick-by-tick trace of the buggy tick (1.21.4, player at `(0.7, 61.0, -0.6795)`,
`maxUpStep = 0.6`, next stair slab top at `y = 61.5`):

| probe | input | result |
|---|---|---|
| baseline collide | `(0.0335, -0.0784, -0.2012)` | `(0, 0, -0.0205)` |
| `stepUpMovement` | `(0.0335, 0.6, -0.2012)` | `(0, 0.6, -0.2012)` → accepted, hDist improves |
| `stepOnlyMovement` (box expanded towards movement, i.e. into the wall column) | `(0, 0.6, 0)` | `(0, 0.2, 0)` — a wall block 0.2 above the head clips it |
| `adjustedStepUp` | `(0.0335, 0, -0.2012)` | rejected by hDist — **but `playerAABB` is now permanently 0.2 higher** |
| final down-probe, runs on box `61.8..63.6` instead of `61.6..63.4` | `(0, -0.6784, 0)` | `(0, -0.3, 0)` |

Result: `movement.y = 0.6 - 0.3 = +0.3`, player at `y = 61.3` — between the step's bottom
(`61.0`) and its top (`61.5`), i.e. embedded in the block. From the next tick on the player
sinks into the geometry and wedges against the stair riser: position freezes at
`(0.7, 61.0, -1.2)` with `vel.z = 0` forever. With a slab instead of stairs, the player
walks *through* the step at floor level.

Trigger conditions (all three needed):

1. step-up runs (`onGround`, horizontal collision, hDist improves);
2. movement is diagonal, so `stepOnlyMovement`'s expanded box reaches into the wall column;
3. that column has a block within `maxUpStep` above the player's head (a wall 3+ blocks
   tall, or any ceiling). With a 2-block-tall wall the step-up is correct.

## Vanilla reference

The implemented algorithm is vanilla's step-up for **≤ 1.20.6**, and there both follow-up
probes are built from the *original* `aABB` via `AABB#move`, which returns a copy:

[1.20.6 `Entity#collide`, L875–L899](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.20.6/minecraft/src/net/minecraft/world/entity/Entity.java#L875-L899):

```java
Vec3 vec33 = collideBoundingBox(this, new Vec3(vec3.x, this.maxUpStep(), vec3.z), aABB, this.level(), list);
Vec3 vec34 = collideBoundingBox(this, new Vec3(0.0, this.maxUpStep(), 0.0), aABB.expandTowards(vec3.x, 0.0, vec3.z), this.level(), list);
if (vec34.y < this.maxUpStep()) {
    Vec3 vec35 = collideBoundingBox(this, new Vec3(vec3.x, 0.0, vec3.z), aABB.move(vec34), this.level(), list).add(vec34);
    if (vec35.horizontalDistanceSqr() > vec33.horizontalDistanceSqr()) {
        vec33 = vec35;
    }
}

if (vec33.horizontalDistanceSqr() > vec32.horizontalDistanceSqr()) {
    return vec33.add(collideBoundingBox(this, new Vec3(0.0, -vec33.y + vec3.y, 0.0), aABB.move(vec33), this.level(), list));
}
```

Same code in [1.16.5 `Entity#collide`, L676–L709](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.16.5/minecraft/src/net/minecraft/world/entity/Entity.java#L676-L709).

Vanilla's `AABB` is immutable, which is why this class of bug cannot happen there —
[1.20.6 `AABB#move`, L214–L231](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.20.6/minecraft/src/net/minecraft/world/phys/AABB.java#L214-L231):

```java
public AABB move(double d, double e, double f) {
    return new AABB(this.minX + d, this.minY + e, this.minZ + f, this.maxX + d, this.maxY + e, this.maxZ + f);
}

public AABB move(Vec3 vec3) {
    return this.move(vec3.x, vec3.y, vec3.z);
}
```

`node-aabb` mirrors both semantics: `translate`/`translateVec` mutate `this`,
`move`/`moveCoords` return a new box. The step-up path used the mutating pair.

## The change

```diff
-          playerAABB.translateVec(stepOnlyMovement),
+          playerAABB.move(stepOnlyMovement),
...
-              playerAABB.translateVec(stepUpMovement),
+              playerAABB.move(stepUpMovement),
```

No behavioural change outside the two probes: `playerAABB` is a fresh `player.getBB()` box
and is not read after this block, so the only effect is that the second and third probes
now start from the unmodified box, as in vanilla.

## Version scope and data coverage

The defect is in shared collision code with no version branches, so the matrix is there to
prove exactly that: the same signature on every dataset, and no version-gated behaviour
introduced by the fix.

Automated coverage uses `minecraft-data@3.111.0` and `prismarine-block@1.23.0`, and runs
the identical scenario on **20 datasets**: 1.8.9, 1.9.4, 1.10.2, 1.11.2, 1.12.2, 1.13.2,
1.14.4, 1.15.2, 1.16.5, 1.17.1, 1.18.2, 1.19.4, 1.20.1, 1.20.4, 1.20.5, 1.20.6, 1.21.1,
1.21.4, 1.21.8, 1.21.11. 1.20.4/1.20.5 are both present on purpose — that is where
`applyMovement` switches from the static step height to the attribute-aware branch.

Result — the bug is version-independent, and so is the fix:

| case | datasets | before | after |
|---|---|---|---|
| slab step (0.5) + diagonal into wall | all 20 | `y = 60.3` (inside the slab), then the player sinks through the step | `y = 60.5`, walks on top |
| `acacia_stairs` staircase + diagonal into wall | 16 (1.12.2 → 1.21.11) | `+0.3` step-up, then permanently wedged at a fixed `z` with `vel.z = 0` | `+0.5` per step, climb continues |
| full-block step, step-height attribute `1.0` | 4 (1.21.1 → 1.21.11) | `y = 60.8` inside the block, then sinks through a solid block | `y = 61.0`, stands on top |
| slab step, step-height attribute `0.4` | 4 (1.21.1 → 1.21.11) | stops at the slab face (control case: no step-up, so no aliasing) | unchanged |

Skips are decided at runtime from the dataset, not from hardcoded version cutoffs:

- **stairs, 1.8.9–1.11.2:** `minecraft-data` returns the *same* stair collision shape for
  every `facing` value on pre-flattening datasets, so a staircase cannot be placed
  deterministically there. Claiming those rows as stair coverage would be misleading. The
  slab case still covers those versions through the same code path.
- **the two attribute cases below 1.21.1:** this `minecraft-data` version only ships a
  `stepHeight` attribute descriptor from 1.21 on, so `extractAttribute` returns `null` and
  the attribute-aware branch falls back to the static step height.

## Version boundaries

**1.20.5 — step height becomes an attribute.** `applyMovement` uses `ctx.stepHeight` below
1.20.5 and `player.attributes[stepHeightAttribute] ?? ctx.stepHeight` from 1.20.5 on. What
the matrix actually covers, stated precisely:

| datasets | branch taken | value used |
|---|---|---|
| 1.8.9 – 1.20.4 | static `ctx.stepHeight` | 0.6 |
| 1.20.5 – 1.20.6 | attribute-aware, descriptor absent in this `minecraft-data` | fallback 0.6 |
| 1.21.1 – 1.21.11 (slab/stairs cases) | attribute-aware, no attribute set on the entity | fallback 0.6 |
| 1.21.1 – 1.21.11 (dedicated cases) | attribute-aware, attribute set | 1.0 and 0.4 |

The last row is what proves the attribute is really read rather than shadowed by the
default: with `1.0` the entity steps onto a full block (and, before this fix, sank *into* a
solid block — `y = 60.8`), with `0.4` it refuses to climb the 0.5 slab at all.

**1.21 — vanilla replaces the three step-up probes with candidate step-up heights**
([1.21 `Entity#collide`, L876–L905](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21/minecraft/src/net/minecraft/world/entity/Entity.java#L876-L905),
[`collectCandidateStepUpHeights`, L907–L926](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21/minecraft/src/net/minecraft/world/entity/Entity.java#L907-L926);
verified absent in 1.19.4 through 1.20.6). This is a real gap — the package implements the
≤ 1.20.6 algorithm on all versions — but it is not what this PR changes, and this PR does
not make it worse.

To check that concretely rather than assume it, I ported 1.21 `Entity#collide` as a
reference implementation and evaluated three variants — shipped, fixed, and the 1.21
reference — on the same per-tick inputs, on 1.21.4 and 1.21.11 (identical results on both):

| | slab scenario | stairs scenario |
|---|---|---|
| ticks simulated | 16 | 24 |
| ticks where step-up changed the result | 1 | 9 |
| ticks where the aliasing changes the outcome | 1 | 4 |
| shipped vs 1.21 reference | differs on those alias ticks (`+0.3` vs `+0.5`) | differs on those 4 alias ticks |
| fixed vs 1.21 reference | agrees on all 16 ticks | agrees on all 24 ticks |
| largest component difference, fixed vs reference | `1.4e-15` | `5.7e-15` |

Two honest qualifications:

- The step-up ticks where the aliasing does *not* change anything are the ones where the
  "step only" probe is not clipped, so the mutation never happens. The shipped code is only
  wrong where that probe is clipped — which is exactly the diagonal-into-a-tall-wall case.
- "Agrees" means agrees numerically, not bit-for-bit: the non-step-up ticks are exactly
  equal, while the step-up ticks reach the same `0.5` through different arithmetic and so
  differ in the last bits (bounded by the numbers above).

The harness drives one simulation with the fixed engine, captures each tick's collide input
and re-evaluates all three variants on it. That is a per-input comparison, so the
whole-trajectory claim rests on induction rather than on three parallel simulations: the
movement the engine actually applied equals the 1.21 reference on every tick of both
scenarios, so identical state at tick *t* implies identical movement and therefore identical
state at *t+1*, down to the float noise above.

Conclusion: on 1.21+ data the current output is wrong *because of the aliasing*, not because
of the algorithm revision. No version gate is needed for this change.

(Caveat on the reference port: candidate heights come from the collider boxes' Y edges,
which for block shapes is the same set `VoxelShape#getCoords(Axis.Y)` yields; everything
else reuses the package's own collision helpers.)

## Tests

New `tests/unit/botcraft/stepUpAgainstWall.test.ts` — the four cases above across the 20
datasets (80 cases, 36 of them skipped by the runtime data checks explained above):

- before this change: **4 passing / 40 failing / 36 pending**;
- after: **44 passing / 36 pending**;
- the 4 that pass either way are the `0.4` attribute cases — with a step height below the
  step there is no step-up, hence no aliasing. They are in the suite as a control, so a
  blanket failure cannot be mistaken for a real signal;
- full suite goes from **67 passing / 5 failing** to **111 passing / 36 pending / 5
  failing**; the 5 failures are the pre-existing water-flow tests in `waterPhysics.test.ts`
  on current `master`, unchanged by this PR.

## Manual verification

Manually verified in a live runtime environment on Minecraft **1.17.1**. Walking diagonally into the corridor wall while climbing the staircase now works correctly: the player climbs smoothly without becoming embedded, getting stuck, or repeatedly jumping in place.