### PR TITLE
feat(physics): add multiversion horse physics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ export { PhysicsUtilWrapper } from "./wrapper";
 
 export { EPhysicsCtx, PhysicsWorldSettings } from "./physics/settings";
 export { BaseSimulator } from "./simulators";
-export { EntityPhysics, BotcraftPhysics, BoatPhysics } from "./physics/engines";
-export { EntityState, PlayerState, PlayerPoses, IEntityState, BoatState, BoatStatus } from "./physics/states";
+export { EntityPhysics, BotcraftPhysics, BoatPhysics, HorsePhysics } from "./physics/engines";
+export { EntityState, PlayerState, PlayerPoses, IEntityState, BoatState, BoatStatus, HorseState } from "./physics/states";
 export { ControlStateHandler } from "./physics/player";
 
 export type { SimulationGoal, Controller, OnGoalReachFunction }from "./simulators";

--- a/src/physics/engines/horsePhysics.ts
+++ b/src/physics/engines/horsePhysics.ts
@@ -1,0 +1,382 @@
+import { AABB } from "@nxg-org/mineflayer-util-plugin";
+import md from "minecraft-data";
+import { Block } from "prismarine-block";
+import { Vec3 } from "vec3";
+import { EPhysicsCtx } from "../settings/entityPhysicsCtx";
+import { HorsePhysicsSettings, resolveHorseSettings, computeHorseJumpPower } from "../settings/horseSettings";
+import { getHorseBlockBelowAffectingMovementPos } from "../settings/horseBlockSupport";
+import { HorseState } from "../states/horseState";
+import { IEntityState } from "../states";
+import { EntityPhysics } from "./entityPhysics";
+
+type PhysicsWorld = {
+  getBlock(pos: Vec3): Block | null | undefined;
+};
+
+type LavaFluidScan = {
+  fluidHeight: number;
+  isInLava: boolean;
+};
+
+export class HorsePhysics extends EntityPhysics {
+  private readonly horseSettings: HorsePhysicsSettings;
+
+  constructor(mcData: md.IndexedData) {
+    super(mcData);
+    this.horseSettings = resolveHorseSettings(mcData);
+  }
+
+  simulate(simCtx: EPhysicsCtx, world: PhysicsWorld): IEntityState {
+    if (!(simCtx.state instanceof HorseState)) {
+      return super.simulate(simCtx, world);
+    }
+
+    const state = simCtx.state;
+    if (!this.isWorldReady(simCtx, state, world)) {
+      state.worldReady = false;
+      return state;
+    }
+
+    state.worldReady = true;
+    const cfg = this.horseSettings;
+
+    this.applyHorseTravelContext(simCtx, state, cfg);
+
+    this.updateFluidState(simCtx, state, world);
+    this.applyRidersJump(simCtx, state, world, cfg);
+
+    const { strafe, forward } = state.getTravelInput();
+    if (state.isInWater) {
+      this.travelInWater(simCtx, state, strafe, forward, world, cfg);
+    } else if (state.isInLava) {
+      this.travelInLava(simCtx, state, strafe, forward, world, cfg);
+    } else {
+      this.travelInAir(simCtx, state, strafe, forward, world, cfg);
+    }
+
+    state.age++;
+    return state;
+  }
+
+  private getHorseBB(simCtx: EPhysicsCtx, state: HorseState): AABB {
+    return this.getEntityBB(simCtx, state.pos);
+  }
+
+  private getLavaQueryBB(simCtx: EPhysicsCtx, _state: HorseState): AABB {
+    // Vanilla LivingEntity.updateFluidHeightAndDoFluidPushing: getBoundingBox().deflate(0.001)
+    return this.getHorseBB(simCtx, _state).contract(0.001, 0.001, 0.001);
+  }
+
+  private getWorldReadinessBlockRange(simCtx: EPhysicsCtx, state: HorseState): {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+    minZ: number;
+    maxZ: number;
+  } {
+    const bb = this.getHorseBB(simCtx, state);
+    const input = state.getTravelInput();
+    const yaw = Math.PI - state.yaw;
+    const sin = Math.sin(yaw);
+    const cos = Math.cos(yaw);
+    const dx = input.strafe * cos - input.forward * sin;
+    const dz = input.forward * cos + input.strafe * sin;
+    const swept = bb.clone().extend(dx, state.vel.y, dz);
+    const stepBB = bb.clone().extend(dx, simCtx.stepHeight, dz);
+    const margin = 1;
+
+    return {
+      minX: Math.floor(Math.min(bb.minX, swept.minX, stepBB.minX)) - margin,
+      maxX: Math.ceil(Math.max(bb.maxX, swept.maxX, stepBB.maxX)) + margin,
+      minY: Math.floor(Math.min(bb.minY, swept.minY, stepBB.minY)) - margin,
+      maxY: Math.ceil(Math.max(bb.maxY, swept.maxY, stepBB.maxY)) + margin,
+      minZ: Math.floor(Math.min(bb.minZ, swept.minZ, stepBB.minZ)) - margin,
+      maxZ: Math.ceil(Math.max(bb.maxZ, swept.maxZ, stepBB.maxZ)) + margin,
+    };
+  }
+
+  private isWorldReady(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld): boolean {
+    const range = this.getWorldReadinessBlockRange(simCtx, state);
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = range.minY; cursor.y < range.maxY; cursor.y++) {
+      for (cursor.z = range.minZ; cursor.z < range.maxZ; cursor.z++) {
+        for (cursor.x = range.minX; cursor.x < range.maxX; cursor.x++) {
+          if (world.getBlock(cursor) == null) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  private updateFluidState(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld): void {
+    const vel = state.vel;
+    const waterBB = this.getHorseBB(simCtx, state).contract(0.001, state.vel.y < 0 ? 0.401 : 0.001, 0.001);
+    state.isInWater = this.isInWaterApplyCurrent(waterBB, vel, world);
+
+    const lavaScan = this.scanLavaFluid(simCtx, state, world);
+    state.isInLava = lavaScan.isInLava;
+  }
+
+  private applyHorseTravelContext(simCtx: EPhysicsCtx, state: HorseState, cfg: HorsePhysicsSettings): void {
+    simCtx.gravity = cfg.gravity;
+    simCtx.waterGravity = cfg.gravity / 16;
+    simCtx.lavaGravity = cfg.gravity / 4;
+    simCtx.airdrag = cfg.verticalDrag;
+    simCtx.airborneInertia = cfg.groundFrictionMultiplier;
+    simCtx.airborneAccel = state.movementSpeed * cfg.airborneAccelFactor;
+    simCtx.waterInertia = cfg.waterInertia;
+    simCtx.lavaInertia = cfg.lavaHorizontalInertia;
+    simCtx.liquidAccel = cfg.liquidAccel;
+    simCtx.stepHeight = cfg.stepHeight;
+    simCtx.useControls = false;
+    // gravityThenDrag is preserved for living-context compatibility only;
+    // scoped air/water/lava branches encode their respective vanilla order directly.
+    simCtx.gravityThenDrag = true;
+    simCtx.collisionBehavior = { blockEffects: true, affectedAfterCollision: true };
+  }
+
+  private getBlockBelowAffectingMovement(
+    simCtx: EPhysicsCtx,
+    state: HorseState,
+    world: PhysicsWorld,
+  ): Vec3 {
+    const bb = this.getHorseBB(simCtx, state);
+    return getHorseBlockBelowAffectingMovementPos(
+      this.data,
+      state.pos,
+      bb.minY,
+      state.supportingBlockPos,
+      (pos) => world.getBlock(pos),
+    );
+  }
+
+  private getGroundFriction(
+    simCtx: EPhysicsCtx,
+    state: HorseState,
+    world: PhysicsWorld,
+    cfg: HorsePhysicsSettings,
+  ): number {
+    if (!state.onGround) return 1.0;
+    const blockPos = this.getBlockBelowAffectingMovement(simCtx, state, world);
+    const block = world.getBlock(blockPos);
+    if (!block || block.boundingBox === "empty") return cfg.defaultBlockFriction;
+    return Math.fround(this.blockSlipperiness[block.type] ?? cfg.defaultBlockFriction);
+  }
+
+  private getBlockJumpFactor(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld, cfg: HorsePhysicsSettings): number {
+    const posBlock = world.getBlock(state.pos.floored());
+    const belowBlock = world.getBlock(this.getBlockBelowAffectingMovement(simCtx, state, world));
+    const posFactor = this.getBlockJumpFactorForBlock(posBlock, cfg);
+    const belowFactor = this.getBlockJumpFactorForBlock(belowBlock, cfg);
+    return posFactor === 1.0 ? belowFactor : posFactor;
+  }
+
+  private getBlockJumpFactorForBlock(block: Block | null | undefined, cfg: HorsePhysicsSettings): number {
+    if (!block) return 1.0;
+    if (block.type === this.honeyblockId) return cfg.honeyJumpFactor;
+    return 1.0;
+  }
+
+  /** executeRidersJump — direct Y assignment, no Math.max. */
+  private applyRidersJump(
+    simCtx: EPhysicsCtx,
+    state: HorseState,
+    world: PhysicsWorld,
+    cfg: HorsePhysicsSettings,
+  ): void {
+    if (!state.onGround) return;
+    if (state.jumpPendingScale <= 0 || state.isJumping) return;
+
+    const blockJumpFactor = this.getBlockJumpFactor(simCtx, state, world, cfg);
+    state.vel.y = computeHorseJumpPower(
+      state.jumpStrength,
+      state.jumpPendingScale,
+      blockJumpFactor,
+      state.jumpBoost,
+      this.data,
+    );
+    state.isJumping = true;
+    state.onGround = false;
+
+    const { forward } = state.getTravelInput();
+    if (forward > 0) {
+      const notchianYaw = Math.PI - state.yaw;
+      const sin = Math.sin(notchianYaw);
+      const cos = Math.cos(notchianYaw);
+      const impulse = cfg.forwardJumpImpulse * state.jumpPendingScale;
+      state.vel.x -= impulse * sin;
+      state.vel.z += impulse * cos;
+    }
+
+    state.jumpPendingScale = 0;
+  }
+
+  private travelInAir(
+    simCtx: EPhysicsCtx,
+    state: HorseState,
+    strafe: number,
+    forward: number,
+    world: PhysicsWorld,
+    cfg: HorsePhysicsSettings,
+  ): void {
+    const groundFriction = this.getGroundFriction(simCtx, state, world, cfg);
+    const horizontalFriction = groundFriction * cfg.groundFrictionMultiplier;
+    const acceleration = state.onGround
+      ? state.movementSpeed *
+        (cfg.frictionInfluencedSpeedFactor / (groundFriction * groundFriction * groundFriction))
+      : state.movementSpeed * cfg.airborneAccelFactor;
+
+    this.applyHorseHeading(simCtx, strafe, forward, acceleration);
+    this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
+
+    state.vel.y = (state.vel.y - cfg.gravity) * cfg.verticalDrag;
+    state.vel.x *= horizontalFriction;
+    state.vel.z *= horizontalFriction;
+
+    if (!state.onGround && state.vel.y <= 0) {
+      state.isJumping = false;
+    }
+    if (state.onGround) {
+      state.isJumping = false;
+      state.clearGroundJumpPending();
+    }
+  }
+
+  private travelInWater(
+    simCtx: EPhysicsCtx,
+    state: HorseState,
+    strafe: number,
+    forward: number,
+    world: PhysicsWorld,
+    cfg: HorsePhysicsSettings,
+  ): void {
+    const lastY = state.pos.y;
+    this.applyHorseHeading(simCtx, strafe, forward, cfg.liquidAccel);
+    this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
+
+    // Vanilla LivingEntity.travel water branch: drag then getFluidFallingAdjustedMovement (gravity/16).
+    state.vel.x *= cfg.waterInertia;
+    state.vel.y = state.vel.y * cfg.waterInertia - simCtx.waterGravity;
+    state.vel.z *= cfg.waterInertia;
+
+    this.applyOutOfLiquidImpulse(simCtx, state, world, lastY);
+  }
+
+  private travelInLava(
+    simCtx: EPhysicsCtx,
+    state: HorseState,
+    strafe: number,
+    forward: number,
+    world: PhysicsWorld,
+    cfg: HorsePhysicsSettings,
+  ): void {
+    const lastY = state.pos.y;
+    this.applyHorseHeading(simCtx, strafe, forward, cfg.liquidAccel);
+    this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
+
+    const { fluidHeight } = this.scanLavaFluid(simCtx, state, world);
+    const lavaScale = cfg.lavaHorizontalInertia;
+    if (fluidHeight <= cfg.lavaShallowThreshold) {
+      state.vel.x *= lavaScale;
+      state.vel.y = state.vel.y * cfg.waterInertia - simCtx.waterGravity;
+      state.vel.z *= lavaScale;
+    } else {
+      state.vel.x *= lavaScale;
+      state.vel.y *= lavaScale;
+      state.vel.z *= lavaScale;
+    }
+
+    state.vel.y -= simCtx.lavaGravity;
+
+    this.applyOutOfLiquidImpulse(simCtx, state, world, lastY);
+  }
+
+  private applyOutOfLiquidImpulse(
+    simCtx: EPhysicsCtx,
+    state: HorseState,
+    world: PhysicsWorld,
+    lastY: number,
+  ): void {
+    if (
+      state.isCollidedHorizontally &&
+      this.doesNotCollide(simCtx, state.pos.offset(state.vel.x, 0.6 - state.pos.y + lastY, state.vel.z), world)
+    ) {
+      state.vel.y = simCtx.worldSettings.outOfLiquidImpulse;
+    }
+  }
+
+  /** Vanilla getFluidHeight(FluidTags.LAVA) scoped to horse BB.
+   *  Lava fluid flow pushing (updateFluidHeightAndDoFluidPushing) is out of scope for this PR. */
+  private scanLavaFluid(simCtx: EPhysicsCtx, state: HorseState, world: PhysicsWorld): LavaFluidScan {
+    const bb = this.getLavaQueryBB(simCtx, state);
+    let maxFluidHeight = 0;
+    let isInLava = false;
+    const cursor = new Vec3(0, 0, 0);
+
+    for (cursor.y = Math.floor(bb.minY); cursor.y <= Math.floor(bb.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(bb.minZ); cursor.z <= Math.floor(bb.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(bb.minX); cursor.x <= Math.floor(bb.maxX); cursor.x++) {
+          const block = world.getBlock(cursor);
+          if (!block || block.type !== this.lavaId) continue;
+
+          const blockFluidHeight = this.getLavaFluidHeightInBlock(block, world, cursor);
+          if (blockFluidHeight <= 0) continue;
+
+          const fluidBottom = cursor.y;
+          const fluidTop = fluidBottom + blockFluidHeight;
+          // Vanilla: fluid present when fluidTop >= bb.minY (touching surface counts).
+          if (fluidTop < bb.minY || fluidBottom >= bb.maxY) continue;
+
+          isInLava = true;
+          const heightInEntity = Math.min(fluidTop, bb.maxY) - bb.minY;
+          if (heightInEntity > maxFluidHeight) {
+            maxFluidHeight = heightInEntity;
+          }
+        }
+      }
+    }
+
+    return { fluidHeight: maxFluidHeight, isInLava };
+  }
+
+  private getLavaFluidHeightInBlock(block: Block, world: PhysicsWorld, pos: Vec3): number {
+    const above = world.getBlock(pos.offset(0, 1, 0));
+    if (above && above.type === this.lavaId) {
+      return 1;
+    }
+    return 1 - this.getLavaLiquidHeightFraction(block);
+  }
+
+  /** Filled fraction of block column: source = 8/9 (LivingEntity.getLiquidHeight). */
+  private getLavaLiquidHeightFraction(block: Block): number {
+    const depth = this.getLavaRenderedDepth(block);
+    return (depth + 1) / 9;
+  }
+
+  private getLavaRenderedDepth(block: Block): number {
+    const props = block.getProperties?.();
+    if (props && props.level != null) {
+      const level = typeof props.level === "number" ? props.level : parseInt(String(props.level), 10);
+      if (!Number.isNaN(level)) {
+        return level >= 8 ? 0 : level;
+      }
+    }
+    const meta = block.metadata;
+    return meta >= 8 ? 0 : meta;
+  }
+
+  private applyHorseHeading(simCtx: EPhysicsCtx, strafe: number, forward: number, acceleration: number): void {
+    const state = simCtx.state as HorseState;
+    const yaw = Math.PI - state.yaw;
+    const sin = Math.sin(yaw);
+    const cos = Math.cos(yaw);
+    const offsetX = strafe * cos - forward * sin;
+    const offsetZ = forward * cos + strafe * sin;
+    state.vel.x += offsetX * acceleration;
+    state.vel.z += offsetZ * acceleration;
+  }
+}

--- a/src/physics/engines/horsePhysics.ts
+++ b/src/physics/engines/horsePhysics.ts
@@ -3,7 +3,7 @@ import md from "minecraft-data";
 import { Block } from "prismarine-block";
 import { Vec3 } from "vec3";
 import { EPhysicsCtx } from "../settings/entityPhysicsCtx";
-import { HorsePhysicsSettings, resolveHorseSettings, computeHorseJumpPower } from "../settings/horseSettings";
+import { HorsePhysicsSettings, resolveHorseSettings, computeHorseJumpPower, resolveWaterHorizontalSlowDown } from "../settings/horseSettings";
 import { getHorseBlockBelowAffectingMovementPos } from "../settings/horseBlockSupport";
 import { HorseState } from "../states/horseState";
 import { IEntityState } from "../states";
@@ -128,7 +128,7 @@ export class HorsePhysics extends EntityPhysics {
     simCtx.airdrag = cfg.verticalDrag;
     simCtx.airborneInertia = cfg.groundFrictionMultiplier;
     simCtx.airborneAccel = state.movementSpeed * cfg.airborneAccelFactor;
-    simCtx.waterInertia = cfg.waterInertia;
+    simCtx.waterInertia = resolveWaterHorizontalSlowDown(state.species, this.data);
     simCtx.lavaInertia = cfg.lavaHorizontalInertia;
     simCtx.liquidAccel = cfg.liquidAccel;
     simCtx.stepHeight = cfg.stepHeight;
@@ -258,10 +258,13 @@ export class HorsePhysics extends EntityPhysics {
     this.applyHorseHeading(simCtx, strafe, forward, cfg.liquidAccel);
     this.moveEntity(simCtx, state.vel.x, state.vel.y, state.vel.z, world);
 
+    const waterHorizontalSlowDown = resolveWaterHorizontalSlowDown(state.species, this.data);
+    const liquidVerticalInertia = cfg.liquidVerticalInertia;
+
     // Vanilla LivingEntity.travel water branch: drag then getFluidFallingAdjustedMovement (gravity/16).
-    state.vel.x *= cfg.waterInertia;
-    state.vel.y = state.vel.y * cfg.waterInertia - simCtx.waterGravity;
-    state.vel.z *= cfg.waterInertia;
+    state.vel.x *= waterHorizontalSlowDown;
+    state.vel.y = state.vel.y * liquidVerticalInertia - simCtx.waterGravity;
+    state.vel.z *= waterHorizontalSlowDown;
 
     this.applyOutOfLiquidImpulse(simCtx, state, world, lastY);
   }
@@ -280,9 +283,10 @@ export class HorsePhysics extends EntityPhysics {
 
     const { fluidHeight } = this.scanLavaFluid(simCtx, state, world);
     const lavaScale = cfg.lavaHorizontalInertia;
+    const liquidVerticalInertia = cfg.liquidVerticalInertia;
     if (fluidHeight <= cfg.lavaShallowThreshold) {
       state.vel.x *= lavaScale;
-      state.vel.y = state.vel.y * cfg.waterInertia - simCtx.waterGravity;
+      state.vel.y = state.vel.y * liquidVerticalInertia - simCtx.waterGravity;
       state.vel.z *= lavaScale;
     } else {
       state.vel.x *= lavaScale;
@@ -371,11 +375,24 @@ export class HorsePhysics extends EntityPhysics {
 
   private applyHorseHeading(simCtx: EPhysicsCtx, strafe: number, forward: number, acceleration: number): void {
     const state = simCtx.state as HorseState;
+    const lengthSqr = strafe * strafe + forward * forward;
+    if (lengthSqr < 1e-7) {
+      return;
+    }
+
+    let normStrafe = strafe;
+    let normForward = forward;
+    if (lengthSqr > 1.0) {
+      const length = Math.sqrt(lengthSqr);
+      normStrafe = strafe / length;
+      normForward = forward / length;
+    }
+
     const yaw = Math.PI - state.yaw;
     const sin = Math.sin(yaw);
     const cos = Math.cos(yaw);
-    const offsetX = strafe * cos - forward * sin;
-    const offsetZ = forward * cos + strafe * sin;
+    const offsetX = normStrafe * cos - normForward * sin;
+    const offsetZ = normForward * cos + normStrafe * sin;
     state.vel.x += offsetX * acceleration;
     state.vel.z += offsetZ * acceleration;
   }

--- a/src/physics/engines/index.ts
+++ b/src/physics/engines/index.ts
@@ -1,5 +1,6 @@
 export * from "./entityPhysics"
 export * from "./botcraft"
 export * from "./boatPhysics"
+export * from "./horsePhysics"
 export * from "./IPhysics"
 

--- a/src/physics/info/entity_physics.json
+++ b/src/physics/info/entity_physics.json
@@ -90,6 +90,34 @@
             "airdrag": 1
         }
     },
+    "horses": {
+        "default": {
+            "defaultMovementSpeed": 0.225,
+            "defaultJumpStrength": 0.7,
+            "inputForwardScale": 0.98,
+            "inputStrafeScale": 0.49,
+            "inputBackwardScale": 0.25,
+            "forwardJumpImpulse": 0.4,
+            "honeyJumpFactor": 0.5,
+            "stepHeight": 1.0,
+            "gravity": 0.08,
+            "airborneInertia": 0.91,
+            "airborneAccelFactor": 0.1,
+            "waterInertia": 0.8,
+            "liquidAccel": 0.02,
+            "groundFrictionMultiplier": 0.91,
+            "frictionInfluencedSpeedFactor": 0.21600002,
+            "defaultBlockFriction": 0.6,
+            "verticalDrag": 0.98,
+            "lavaShallowThreshold": 0.4,
+            "lavaHorizontalInertia": 0.5
+        },
+        "fallbackDimensions": {
+            "height": 1.6,
+            "width": 1.3964844
+        },
+        "overrides": []
+    },
     "boats": {
         "default": {
             "gravity": 0.04,

--- a/src/physics/info/entity_physics.json
+++ b/src/physics/info/entity_physics.json
@@ -103,7 +103,8 @@
             "gravity": 0.08,
             "airborneInertia": 0.91,
             "airborneAccelFactor": 0.1,
-            "waterInertia": 0.8,
+            "liquidVerticalInertia": 0.8,
+            "waterHorizontalSlowDown": 0.8,
             "liquidAccel": 0.02,
             "groundFrictionMultiplier": 0.91,
             "frictionInfluencedSpeedFactor": 0.21600002,
@@ -115,6 +116,11 @@
         "fallbackDimensions": {
             "height": 1.6,
             "width": 1.3964844
+        },
+        "speciesOverrides": {
+            "skeleton_horse": {
+                "waterHorizontalSlowDown": 0.96
+            }
         },
         "overrides": []
     },

--- a/src/physics/settings/horseBlockSupport.ts
+++ b/src/physics/settings/horseBlockSupport.ts
@@ -1,0 +1,92 @@
+import md from "minecraft-data";
+import type { Block } from "prismarine-block";
+import { Vec3 } from "vec3";
+
+/** Vanilla Entity.getOnPos(0.500001F) offset for 1.20+. */
+export const HORSE_BLOCK_BELOW_OFFSET_MODERN = 0.500001;
+/** Vanilla pre-1.20 getBlockPosBelowThatAffectsMyMovement equivalent. */
+export const HORSE_BLOCK_BELOW_OFFSET_1_15 = 0.5000001;
+/** Vanilla 1.14.x block-below lookup uses a full-block step. */
+export const HORSE_BLOCK_BELOW_OFFSET_1_14 = 1.0;
+
+export type HorseBlockBelowMode = "legacy_1_14" | "offset_0_5" | "modern_supporting";
+
+export function getHorseBlockBelowMode(mcData: md.IndexedData): HorseBlockBelowMode {
+  const parts = mcData.version.majorVersion!.split(".").map(Number);
+  const major = parts[0] ?? 0;
+  const minor = parts[1] ?? 0;
+  if (major < 1 || (major === 1 && minor <= 14)) {
+    return "legacy_1_14";
+  }
+  if (major === 1 && minor < 20) {
+    return "offset_0_5";
+  }
+  return "modern_supporting";
+}
+
+/** BlockTags.FENCES membership (vanilla getOnPos gate). */
+export function isVanillaFenceBlock(block: Block | null | undefined): boolean {
+  const name = block?.name ?? "";
+  return name.includes("fence") && !name.includes("fence_gate");
+}
+
+/** BlockTags.WALLS membership (vanilla getOnPos gate). */
+export function isVanillaWallBlock(block: Block | null | undefined): boolean {
+  const name = block?.name ?? "";
+  return name.endsWith("_wall") || name === "cobblestone_wall";
+}
+
+/** FenceGateBlock instances (vanilla getOnPos gate). */
+export function isVanillaFenceGateBlock(block: Block | null | undefined): boolean {
+  const name = block?.name ?? "";
+  return name.includes("fence_gate");
+}
+
+function usesSupportingBlockPosY(
+  supportingBlock: Block | null | undefined,
+  offset: number,
+): boolean {
+  if (offset <= 0.5 && isVanillaFenceBlock(supportingBlock)) {
+    return false;
+  }
+  if (isVanillaWallBlock(supportingBlock)) {
+    return false;
+  }
+  if (isVanillaFenceGateBlock(supportingBlock)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Version-aware block below entity feet used for friction/jump factor.
+ * Mirrors Entity.getBlockPosBelowThatAffectsMyMovement / historical offsets.
+ */
+export function getHorseBlockBelowAffectingMovementPos(
+  mcData: md.IndexedData,
+  pos: Vec3,
+  bbMinY: number,
+  supportingBlockPos: Vec3 | null,
+  getBlock: (pos: Vec3) => Block | null | undefined,
+): Vec3 {
+  const mode = getHorseBlockBelowMode(mcData);
+
+  if (mode === "legacy_1_14") {
+    return new Vec3(Math.floor(pos.x), Math.floor(bbMinY - HORSE_BLOCK_BELOW_OFFSET_1_14), Math.floor(pos.z));
+  }
+
+  if (mode === "offset_0_5") {
+    return new Vec3(Math.floor(pos.x), Math.floor(bbMinY - HORSE_BLOCK_BELOW_OFFSET_1_15), Math.floor(pos.z));
+  }
+
+  const offset = Math.fround(HORSE_BLOCK_BELOW_OFFSET_MODERN);
+  if (supportingBlockPos != null) {
+    const supportingBlock = getBlock(supportingBlockPos);
+    if (usesSupportingBlockPosY(supportingBlock, offset)) {
+      return new Vec3(supportingBlockPos.x, Math.floor(pos.y - offset), supportingBlockPos.z);
+    }
+    return supportingBlockPos.clone();
+  }
+
+  return new Vec3(Math.floor(pos.x), Math.floor(pos.y - offset), Math.floor(pos.z));
+}

--- a/src/physics/settings/horseSettings.ts
+++ b/src/physics/settings/horseSettings.ts
@@ -22,7 +22,8 @@ import info from "../info/entity_physics.json";
  * | defaultBlockFriction          | 0.6F               | settings             |
  * | verticalDrag                  | 0.98F              | settings             |
  * | airborneInertia               | 0.91F              | settings             |
- * | waterInertia                  | 0.8F               | settings             |
+ * | liquidVerticalInertia         | 0.8F               | settings             |
+ * | waterHorizontalSlowDown       | 0.8F               | settings             |
  * | liquidAccel                   | 0.02F              | settings             |
  * | lavaHorizontalInertia         | 0.5F               | settings             |
  * | gravity                       | 0.08D              | never                |
@@ -71,8 +72,10 @@ export interface HorsePhysicsSettings {
   airborneInertia: number;
   /** Scoped LivingEntity travel profile — air acceleration factor (* movementSpeed, 0.1F). */
   airborneAccelFactor: number;
-  /** Scoped LivingEntity travel profile — water/lava shallow Y drag (0.8F). */
-  waterInertia: number;
+  /** Scoped LivingEntity travel profile — water Y and shallow-lava Y drag (0.8F). */
+  liquidVerticalInertia: number;
+  /** LivingEntity#getWaterSlowDown horizontal scale for water X/Z (0.8F; skeleton horse 0.96F). */
+  waterHorizontalSlowDown: number;
   /** Scoped LivingEntity travel profile — liquid input acceleration (0.02F). */
   liquidAccel: number;
   /** Scoped LivingEntity travel profile — getFluidJumpThreshold when eyeHeight > 0.4 (double). */
@@ -86,9 +89,16 @@ export interface HorseDimensions {
   width: number;
 }
 
+export type HorseSpecies = "horse" | "skeleton_horse" | "zombie_horse" | "donkey" | "mule";
+
+export interface HorseSpeciesOverride {
+  waterHorizontalSlowDown?: number;
+}
+
 export interface HorseSettingsSection {
   default: HorsePhysicsSettings;
   fallbackDimensions: HorseDimensions;
+  speciesOverrides?: Partial<Record<HorseSpecies, HorseSpeciesOverride>>;
   overrides: Array<{ versions: string[]; values: Partial<HorsePhysicsSettings> }>;
 }
 
@@ -107,7 +117,8 @@ export const FLOAT32_FIELDS = [
   "defaultBlockFriction",
   "verticalDrag",
   "airborneInertia",
-  "waterInertia",
+  "liquidVerticalInertia",
+  "waterHorizontalSlowDown",
   "liquidAccel",
   "lavaHorizontalInertia",
 ] as const;
@@ -115,6 +126,27 @@ export const FLOAT32_FIELDS = [
 const horseSection = info.horses as unknown as HorseSettingsSection;
 
 const HORSE_ENTITY_NAMES = ["horse", "skeleton_horse", "zombie_horse", "donkey", "mule"] as const;
+
+export function parseHorseSpecies(entityName?: string): HorseSpecies {
+  if (entityName === "skeleton_horse" || entityName === "zombie_horse" || entityName === "donkey" || entityName === "mule") {
+    return entityName;
+  }
+  return "horse";
+}
+
+/** Species-aware horizontal water slowdown (SkeletonHorse#getWaterSlowDown). */
+export function resolveWaterHorizontalSlowDown(
+  species: HorseSpecies,
+  mcData: md.IndexedData,
+  section: HorseSettingsSection = horseSection,
+): number {
+  const settings = resolveHorseSettingsFromSection(mcData, section);
+  const override = section.speciesOverrides?.[species]?.waterHorizontalSlowDown;
+  if (override != null) {
+    return Math.fround(override);
+  }
+  return settings.waterHorizontalSlowDown;
+}
 
 const MOVEMENT_SPEED_ALIASES = [
   "generic.movementSpeed",

--- a/src/physics/settings/horseSettings.ts
+++ b/src/physics/settings/horseSettings.ts
@@ -1,0 +1,340 @@
+import md from "minecraft-data";
+import type { Entity } from "prismarine-entity";
+import * as attributes from "../info/attributes";
+import info from "../info/entity_physics.json";
+
+/**
+ * Precision model (JSON field → Java type → fround site):
+ *
+ * | JSON field                    | Java (vanilla)     | fround when resolved |
+ * |-------------------------------|--------------------|----------------------|
+ * | defaultMovementSpeed          | 0.225F             | settings             |
+ * | defaultJumpStrength           | 0.7D default attr  | never (double)       |
+ * | inputForwardScale             | 0.98F              | settings             |
+ * | inputStrafeScale              | 0.49F              | settings             |
+ * | inputBackwardScale            | 0.25F              | settings             |
+ * | forwardJumpImpulse            | 0.4F               | settings             |
+ * | honeyJumpFactor               | 0.5F               | settings             |
+ * | stepHeight                    | 1.0F               | settings             |
+ * | airborneAccelFactor           | 0.1F               | settings             |
+ * | groundFrictionMultiplier      | 0.91F              | settings             |
+ * | frictionInfluencedSpeedFactor | 0.21600002F        | settings             |
+ * | defaultBlockFriction          | 0.6F               | settings             |
+ * | verticalDrag                  | 0.98F              | settings             |
+ * | airborneInertia               | 0.91F              | settings             |
+ * | waterInertia                  | 0.8F               | settings             |
+ * | liquidAccel                   | 0.02F              | settings             |
+ * | lavaHorizontalInertia         | 0.5F               | settings             |
+ * | gravity                       | 0.08D              | never                |
+ * | lavaShallowThreshold          | 0.4D (threshold)   | never                |
+ *
+ * Runtime (not JSON):
+ * | movementSpeed attribute       | float in getRiddenSpeed | extractor (always fround) |
+ * | jumpStrength attribute        | double pre-1.21; float cast in getJumpPower 1.21+ | extractor fround 1.21+ only |
+ * | jump power chain              | double pre-1.21    | computeHorseJumpPower version branch |
+ * | jumpBoostPower                | 0.1F * level       | computeJumpBoostPower |
+ * | charge/pending scale          | float literals     | computeChargeScale / computePendingJumpScale |
+ * | block slipperiness          | float per block    | fround at read in physics |
+ *
+ * Vec3 results: double arithmetic; never fround final position/velocity.
+ */
+
+/** Horse-specific tuning from AbstractHorse (input, jump). */
+export interface HorsePhysicsSettings {
+  /** Default MOVEMENT_SPEED attribute (AbstractHorse 1.17.1:705). */
+  defaultMovementSpeed: number;
+  /** Default JUMP_STRENGTH attribute (AbstractHorse 1.17.1). */
+  defaultJumpStrength: number;
+  /** Forward input scale from getRiddenInput (0.98F). */
+  inputForwardScale: number;
+  /** Strafe input scale (= inputForwardScale * 0.5). */
+  inputStrafeScale: number;
+  /** Backward input multiplier when forward <= 0 (0.25F). */
+  inputBackwardScale: number;
+  /** Forward jump impulse coefficient (executeRidersJump 0.4F). */
+  forwardJumpImpulse: number;
+  /** getBlockJumpFactor for honey blocks (1.15+). */
+  honeyJumpFactor: number;
+  /** Step height while ridden (1.0). */
+  stepHeight: number;
+  /** Scoped LivingEntity travel profile — gravity per tick (double). */
+  gravity: number;
+  /** Scoped LivingEntity travel profile — ground horizontal inertia multiplier (0.91F). */
+  groundFrictionMultiplier: number;
+  /** Scoped LivingEntity travel profile — 0.1627714/triple-slip (0.21600002F). */
+  frictionInfluencedSpeedFactor: number;
+  /** Scoped LivingEntity travel profile — default block slipperiness fallback (0.6F). */
+  defaultBlockFriction: number;
+  /** Scoped LivingEntity travel profile — Y drag after gravity in air (0.98F). */
+  verticalDrag: number;
+  /** Scoped LivingEntity travel profile — ground/air horizontal inertia in air branch (0.91F). */
+  airborneInertia: number;
+  /** Scoped LivingEntity travel profile — air acceleration factor (* movementSpeed, 0.1F). */
+  airborneAccelFactor: number;
+  /** Scoped LivingEntity travel profile — water/lava shallow Y drag (0.8F). */
+  waterInertia: number;
+  /** Scoped LivingEntity travel profile — liquid input acceleration (0.02F). */
+  liquidAccel: number;
+  /** Scoped LivingEntity travel profile — getFluidJumpThreshold when eyeHeight > 0.4 (double). */
+  lavaShallowThreshold: number;
+  /** Scoped LivingEntity travel profile — lava horizontal/deep scale (0.5F). */
+  lavaHorizontalInertia: number;
+}
+
+export interface HorseDimensions {
+  height: number;
+  width: number;
+}
+
+export interface HorseSettingsSection {
+  default: HorsePhysicsSettings;
+  fallbackDimensions: HorseDimensions;
+  overrides: Array<{ versions: string[]; values: Partial<HorsePhysicsSettings> }>;
+}
+
+/** Float32 literals — normalized via Math.fround at settings resolve. */
+export const FLOAT32_FIELDS = [
+  "defaultMovementSpeed",
+  "inputForwardScale",
+  "inputStrafeScale",
+  "inputBackwardScale",
+  "forwardJumpImpulse",
+  "honeyJumpFactor",
+  "stepHeight",
+  "airborneAccelFactor",
+  "groundFrictionMultiplier",
+  "frictionInfluencedSpeedFactor",
+  "defaultBlockFriction",
+  "verticalDrag",
+  "airborneInertia",
+  "waterInertia",
+  "liquidAccel",
+  "lavaHorizontalInertia",
+] as const;
+
+const horseSection = info.horses as unknown as HorseSettingsSection;
+
+const HORSE_ENTITY_NAMES = ["horse", "skeleton_horse", "zombie_horse", "donkey", "mule"] as const;
+
+const MOVEMENT_SPEED_ALIASES = [
+  "generic.movementSpeed",
+  "generic.movement_speed",
+  "minecraft:generic.movement_speed",
+  "minecraft:movement_speed",
+] as const;
+
+const JUMP_STRENGTH_ALIASES = [
+  "horse.jumpStrength",
+  "horse.jump_strength",
+  "generic.jump_strength",
+  "minecraft:generic.jump_strength",
+  "minecraft:jump_strength",
+  "minecraft:horse.jump_strength",
+] as const;
+
+type AttributeProp = {
+  value: number;
+  modifiers: Array<{ uuid: string; operation: number; amount: number }>;
+};
+
+export function usesFloatJumpStrengthPrecision(mcData: md.IndexedData): boolean {
+  const parts = mcData.version.majorVersion!.split(".").map(Number);
+  const major = parts[0] ?? 0;
+  const minor = parts[1] ?? 0;
+  return major > 1 || (major === 1 && minor >= 21);
+}
+
+/** AbstractHorse.getRiddenSpeed casts MOVEMENT_SPEED to float. */
+export function applyMovementSpeedPrecision(value: number): number {
+  return Math.fround(value);
+}
+
+/** JUMP_STRENGTH attribute: fround on read from 1.21+; default fallback stays double. */
+export function applyJumpStrengthPrecision(value: number, mcData: md.IndexedData): number {
+  if (usesFloatJumpStrengthPrecision(mcData)) {
+    return Math.fround(value);
+  }
+  return value;
+}
+
+/** LocalPlayer jumpRidingScale while held: ticks*0.1F or 0.8F + 2.0F/(ticks-9)*0.1F. */
+export function computeChargeScale(ticks: number): number {
+  const f = Math.fround;
+  if (ticks < 10) {
+    return f(f(ticks) * f(0.1));
+  }
+  const divided = f(f(2.0) / f(ticks - 9));
+  const product = f(divided * f(0.1));
+  return f(f(0.8) + product);
+}
+
+/** AbstractHorse.getPlayerJumpPendingScale(i): 0.4F + 0.4F * i / 90.0F. */
+export function computePendingJumpScale(chargeIndex: number): number {
+  const f = Math.fround;
+  if (chargeIndex >= 90) {
+    return f(1.0);
+  }
+  const quotient = f(f(f(0.4) * f(chargeIndex)) / f(90.0));
+  return f(f(0.4) + quotient);
+}
+
+/** LivingEntity.getJumpBoostPower: 0.1F * effectLevel. */
+export function computeJumpBoostPower(jumpBoostEffectLevel: number): number {
+  if (jumpBoostEffectLevel <= 0) {
+    return 0;
+  }
+  const f = Math.fround;
+  return f(f(0.1) * f(jumpBoostEffectLevel));
+}
+
+/**
+ * LivingEntity.getJumpPower(scale): double chain pre-1.21; full float32 chain from 1.21+.
+ * jumpStrength is already attribute-resolved; blockJumpFactor should be frounded by caller when read.
+ */
+export function computeHorseJumpPower(
+  jumpStrength: number,
+  scale: number,
+  blockJumpFactor: number,
+  jumpBoostEffectLevel: number,
+  mcData: md.IndexedData,
+): number {
+  const boost = computeJumpBoostPower(jumpBoostEffectLevel);
+  if (usesFloatJumpStrengthPrecision(mcData)) {
+    const f = Math.fround;
+    const scaled = f(f(jumpStrength) * f(scale));
+    const factored = f(scaled * f(blockJumpFactor));
+    return f(factored + boost);
+  }
+  return jumpStrength * scale * blockJumpFactor + boost;
+}
+
+/** Floor riding charge index sent to onPlayerJump: Mth.floor(scale * 100.0F). */
+export function floorRidingChargeIndex(chargeScale: number): number {
+  const f = Math.fround;
+  return Math.floor(f(f(chargeScale) * f(100.0)));
+}
+
+export function hasValidDimensions(entity: md.Entity | undefined): entity is md.Entity & { height: number; width: number } {
+  return (
+    entity != null &&
+    typeof entity.height === "number" &&
+    Number.isFinite(entity.height) &&
+    entity.height > 0 &&
+    typeof entity.width === "number" &&
+    Number.isFinite(entity.width) &&
+    entity.width > 0
+  );
+}
+
+/** Prefer runtime entity dimensions when finite and positive. */
+export function pickRuntimeDimension(entityValue: number | undefined, fallback: number): number {
+  if (typeof entityValue === "number" && Number.isFinite(entityValue) && entityValue > 0) {
+    return entityValue;
+  }
+  return fallback;
+}
+
+function applyFloat32Normalization(settings: HorsePhysicsSettings): HorsePhysicsSettings {
+  const result = { ...settings };
+  for (const field of FLOAT32_FIELDS) {
+    result[field] = Math.fround(result[field]);
+  }
+  return result;
+}
+
+function resourceKeysFromMcData(mcData: md.IndexedData, names: string[]): string[] {
+  const keys: string[] = [];
+  for (const name of names) {
+    const descriptor = mcData.attributesByName[name] as { resource?: string } | undefined;
+    if (descriptor?.resource) {
+      keys.push(descriptor.resource);
+    }
+  }
+  return keys;
+}
+
+function lookupAttribute(
+  entityAttributes: Entity["attributes"] | undefined,
+  mcData: md.IndexedData,
+  mcDataNames: string[],
+  historicalAliases: readonly string[],
+): AttributeProp | undefined {
+  if (!entityAttributes) return undefined;
+
+  const orderedKeys = [...resourceKeysFromMcData(mcData, mcDataNames), ...historicalAliases];
+  for (const key of orderedKeys) {
+    const attr = entityAttributes[key] as AttributeProp | undefined;
+    if (attr) return attr;
+  }
+  return undefined;
+}
+
+/** Pure function — exported for override tests. */
+export function resolveHorseSettingsFromSection(
+  mcData: md.IndexedData,
+  section: HorseSettingsSection,
+): HorsePhysicsSettings {
+  const majorVersion = mcData.version.majorVersion!;
+  let settings: HorsePhysicsSettings = { ...section.default };
+
+  for (const override of section.overrides) {
+    if (override.versions.includes(majorVersion)) {
+      settings = { ...settings, ...override.values };
+    }
+  }
+
+  return applyFloat32Normalization(settings);
+}
+
+/** Resolve horse physics from the `horses` section of entity_physics.json. */
+export function resolveHorseSettings(mcData: md.IndexedData): HorsePhysicsSettings {
+  return resolveHorseSettingsFromSection(mcData, horseSection);
+}
+
+/** Resolve horse dimensions from minecraft-data, falling back when missing. */
+export function resolveHorseDimensions(
+  mcData: md.IndexedData,
+  entityName?: string,
+  fallback: HorseDimensions = horseSection.fallbackDimensions,
+): HorseDimensions {
+  if (entityName) {
+    const named = mcData.entitiesByName[entityName];
+    if (hasValidDimensions(named)) {
+      return { height: named.height, width: named.width };
+    }
+  }
+
+  for (const name of HORSE_ENTITY_NAMES) {
+    const candidate = mcData.entitiesByName[name];
+    if (hasValidDimensions(candidate)) {
+      return { height: candidate.height, width: candidate.width };
+    }
+  }
+
+  return { ...fallback };
+}
+
+export function getHorseMovementSpeedAttribute(
+  entityAttributes: Entity["attributes"] | undefined,
+  mcData: md.IndexedData,
+  defaultValue: number = resolveHorseSettings(mcData).defaultMovementSpeed,
+): number {
+  const attr = lookupAttribute(entityAttributes, mcData, ["movementSpeed", "generic_movement_speed"], MOVEMENT_SPEED_ALIASES);
+  if (!attr) return defaultValue;
+  return applyMovementSpeedPrecision(attributes.getAttributeValue(attr));
+}
+
+export function getHorseJumpStrengthAttribute(
+  entityAttributes: Entity["attributes"] | undefined,
+  mcData: md.IndexedData,
+  defaultValue: number = resolveHorseSettings(mcData).defaultJumpStrength,
+): number {
+  const attr = lookupAttribute(
+    entityAttributes,
+    mcData,
+    ["horseJumpStrength", "jumpStrength"],
+    JUMP_STRENGTH_ALIASES,
+  );
+  if (!attr) return defaultValue;
+  return applyJumpStrengthPrecision(attributes.getAttributeValue(attr), mcData);
+}

--- a/src/physics/states/entityPose.ts
+++ b/src/physics/states/entityPose.ts
@@ -1,0 +1,12 @@
+import type { Entity } from "prismarine-entity";
+import { PlayerPoses } from "./poses";
+
+export type Heading = {
+  forward: number;
+  strafe: number;
+};
+
+export function getPose(entity: Entity) {
+  const pose = entity.metadata.find((e) => (e as any)?.type === 18);
+  return pose ? ((pose as any).value as number) : PlayerPoses.STANDING;
+}

--- a/src/physics/states/entityState.ts
+++ b/src/physics/states/entityState.ts
@@ -8,10 +8,10 @@ import { ControlStateHandler } from "../player/playerControls";
 import { PlayerState } from "./playerState";
 import { PlayerPoses } from "./poses";
 
-import { IPhysics } from "../engines";
+import { IPhysics } from "../engines/IPhysics";
 import nbt from "prismarine-nbt";
 import {Entity} from "prismarine-entity";
-import { IEntityState } from ".";
+import { IEntityState } from "./iEntityState";
 
 
 

--- a/src/physics/states/horseState.ts
+++ b/src/physics/states/horseState.ts
@@ -9,7 +9,9 @@ import {
   getHorseJumpStrengthAttribute,
   getHorseMovementSpeedAttribute,
   HorsePhysicsSettings,
+  HorseSpecies,
   pickRuntimeDimension,
+  parseHorseSpecies,
   resolveHorseDimensions,
   resolveHorseSettings,
 } from "../settings/horseSettings";
@@ -33,6 +35,7 @@ export class HorseState extends EntityState {
   allowStandSliding = false;
   /** Out of scope for physics engine — saddle gate remains in consumer. */
   saddled = false;
+  species: HorseSpecies = "horse";
 
   worldReady = true;
   attributesReady = false;
@@ -53,9 +56,11 @@ export class HorseState extends EntityState {
     pitch: number,
     control: ControlStateHandler = ControlStateHandler.DEFAULT(),
     settings?: HorsePhysicsSettings,
+    species: HorseSpecies = "horse",
   ) {
     super(ctx, height, halfWidth, pos, vel, onGround, yaw, pitch, control);
     this.settings = settings ?? resolveHorseSettings(ctx.data);
+    this.species = species;
     this.movementSpeed = this.settings.defaultMovementSpeed;
     this.jumpStrength = this.settings.defaultJumpStrength;
   }
@@ -83,6 +88,7 @@ export class HorseState extends EntityState {
       settings,
     );
     state.updateFromHorseEntity(entity);
+    state.species = parseHorseSpecies(entity.name);
     return state;
   }
 
@@ -105,6 +111,9 @@ export class HorseState extends EntityState {
       this.movementSpeed = getHorseMovementSpeedAttribute(entity.attributes, this.ctx.data);
       this.jumpStrength = getHorseJumpStrengthAttribute(entity.attributes, this.ctx.data);
       this.attributesReady = true;
+    }
+    if (entity.name) {
+      this.species = parseHorseSpecies(entity.name);
     }
     return this;
   }
@@ -203,6 +212,7 @@ export class HorseState extends EntityState {
       this.pitch,
       this.control.clone(),
       this.settings,
+      this.species,
     );
     other.movementSpeed = this.movementSpeed;
     other.jumpStrength = this.jumpStrength;
@@ -213,6 +223,7 @@ export class HorseState extends EntityState {
     other.isJumping = this.isJumping;
     other.allowStandSliding = this.allowStandSliding;
     other.saddled = this.saddled;
+    other.species = this.species;
     other.worldReady = this.worldReady;
     other.attributesReady = this.attributesReady;
     other.riderYaw = this.riderYaw;

--- a/src/physics/states/horseState.ts
+++ b/src/physics/states/horseState.ts
@@ -1,0 +1,229 @@
+import type { Entity } from "prismarine-entity";
+import md from "minecraft-data";
+import { Vec3 } from "vec3";
+import type { IPhysics } from "../engines/IPhysics";
+import {
+  computeChargeScale,
+  computePendingJumpScale,
+  floorRidingChargeIndex,
+  getHorseJumpStrengthAttribute,
+  getHorseMovementSpeedAttribute,
+  HorsePhysicsSettings,
+  pickRuntimeDimension,
+  resolveHorseDimensions,
+  resolveHorseSettings,
+} from "../settings/horseSettings";
+import { ControlStateHandler } from "../player/playerControls";
+import { EntityState } from "./entityState";
+
+export type HorseJumpRelease = {
+  released: boolean;
+  jumpBoost: number;
+};
+
+export class HorseState extends EntityState {
+  movementSpeed: number;
+  jumpStrength: number;
+
+  jumpChargeTicks = 0;
+  jumpChargeScale = 0;
+  jumpPendingScale = 0;
+  previousJumpInput = false;
+  isJumping = false;
+  allowStandSliding = false;
+  /** Out of scope for physics engine — saddle gate remains in consumer. */
+  saddled = false;
+
+  worldReady = true;
+  attributesReady = false;
+
+  riderYaw = 0;
+  riderPitch = 0;
+
+  private readonly settings: HorsePhysicsSettings;
+
+  constructor(
+    ctx: IPhysics,
+    height: number,
+    halfWidth: number,
+    pos: Vec3,
+    vel: Vec3,
+    onGround: boolean,
+    yaw: number,
+    pitch: number,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+    settings?: HorsePhysicsSettings,
+  ) {
+    super(ctx, height, halfWidth, pos, vel, onGround, yaw, pitch, control);
+    this.settings = settings ?? resolveHorseSettings(ctx.data);
+    this.movementSpeed = this.settings.defaultMovementSpeed;
+    this.jumpStrength = this.settings.defaultJumpStrength;
+  }
+
+  public static CREATE_FROM_ENTITY(
+    ctx: IPhysics,
+    entity: Entity,
+    control: ControlStateHandler = ControlStateHandler.DEFAULT(),
+  ): HorseState {
+    const settings = resolveHorseSettings(ctx.data);
+    const dims = resolveHorseDimensions(ctx.data, entity.name);
+    const height = pickRuntimeDimension(entity.height, dims.height);
+    const width = pickRuntimeDimension(entity.width, dims.width);
+
+    const state = new HorseState(
+      ctx,
+      height,
+      width / 2,
+      entity.position.clone(),
+      entity.velocity.clone(),
+      entity.onGround ?? false,
+      entity.yaw,
+      entity.pitch,
+      control,
+      settings,
+    );
+    state.updateFromHorseEntity(entity);
+    return state;
+  }
+
+  public static getMovementSpeedFromAttributes(
+    entityAttributes: Entity["attributes"] | undefined,
+    mcData: md.IndexedData,
+  ): number {
+    return getHorseMovementSpeedAttribute(entityAttributes, mcData);
+  }
+
+  public static getJumpStrengthFromAttributes(
+    entityAttributes: Entity["attributes"] | undefined,
+    mcData: md.IndexedData,
+  ): number {
+    return getHorseJumpStrengthAttribute(entityAttributes, mcData);
+  }
+
+  public updateFromHorseEntity(entity: Entity): HorseState {
+    if (entity.attributes) {
+      this.movementSpeed = getHorseMovementSpeedAttribute(entity.attributes, this.ctx.data);
+      this.jumpStrength = getHorseJumpStrengthAttribute(entity.attributes, this.ctx.data);
+      this.attributesReady = true;
+    }
+    return this;
+  }
+
+  public updateControls(control: ControlStateHandler, riderYaw: number, riderPitch: number): HorseState {
+    this.control = control.clone();
+    this.riderYaw = riderYaw;
+    this.riderPitch = riderPitch;
+    this.yaw = riderYaw;
+    this.pitch = Math.fround(riderPitch * 0.5);
+    return this;
+  }
+
+  public updateJumpCharge(jumpInput: boolean): HorseJumpRelease {
+    const result: HorseJumpRelease = { released: false, jumpBoost: 0 };
+
+    if (!jumpInput && this.previousJumpInput) {
+      this.jumpPendingScale = computePendingJumpScale(floorRidingChargeIndex(this.jumpChargeScale));
+      result.released = true;
+      result.jumpBoost = floorRidingChargeIndex(this.jumpChargeScale);
+      this.jumpChargeTicks = -10;
+    } else if (jumpInput && !this.previousJumpInput) {
+      this.jumpChargeTicks = 0;
+      this.jumpChargeScale = 0;
+    } else if (jumpInput) {
+      this.jumpChargeTicks++;
+      this.jumpChargeScale = computeChargeScale(this.jumpChargeTicks);
+    } else {
+      this.jumpChargeScale = 0;
+    }
+
+    this.previousJumpInput = jumpInput;
+    return result;
+  }
+
+  public getTravelInput(): { strafe: number; forward: number } {
+    const control = this.control;
+    const strafe = Math.fround(
+      ((control.left ? 1 : 0) - (control.right ? 1 : 0)) * this.settings.inputStrafeScale,
+    );
+    let forward = Math.fround(
+      ((control.forward ? 1 : 0) - (control.back ? 1 : 0)) * this.settings.inputForwardScale,
+    );
+    if (forward <= 0) {
+      forward = Math.fround(forward * this.settings.inputBackwardScale);
+    }
+    return { strafe, forward };
+  }
+
+  public clearGroundJumpPending(): void {
+    this.jumpPendingScale = 0;
+  }
+
+  public rebaseFromEntity(entity: Entity, options?: { replaceVelocity?: boolean }): HorseState {
+    this.pos.set(entity.position.x, entity.position.y, entity.position.z);
+    if (options?.replaceVelocity !== false) {
+      this.vel.set(entity.velocity.x, entity.velocity.y, entity.velocity.z);
+    }
+    this.yaw = entity.yaw;
+    this.pitch = entity.pitch;
+    this.onGround = entity.onGround ?? false;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    this.isCollidedHorizontally = entityExtras.isCollidedHorizontally ?? false;
+    this.isCollidedVertically = entityExtras.isCollidedVertically ?? false;
+    this.updateFromHorseEntity(entity);
+    return this;
+  }
+
+  public applyToEntity(entity: Entity) {
+    entity.position.set(this.pos.x, this.pos.y, this.pos.z);
+    entity.velocity.set(this.vel.x, this.vel.y, this.vel.z);
+    entity.yaw = this.yaw;
+    entity.pitch = this.pitch;
+    entity.onGround = this.onGround;
+    const entityExtras = entity as Entity & {
+      isCollidedHorizontally?: boolean;
+      isCollidedVertically?: boolean;
+    };
+    entityExtras.isCollidedHorizontally = this.isCollidedHorizontally;
+    entityExtras.isCollidedVertically = this.isCollidedVertically;
+    return this;
+  }
+
+  public clone(): HorseState {
+    const other = new HorseState(
+      this.ctx,
+      this.height,
+      this.halfWidth,
+      this.pos.clone(),
+      this.vel.clone(),
+      this.onGround,
+      this.yaw,
+      this.pitch,
+      this.control.clone(),
+      this.settings,
+    );
+    other.movementSpeed = this.movementSpeed;
+    other.jumpStrength = this.jumpStrength;
+    other.jumpChargeTicks = this.jumpChargeTicks;
+    other.jumpChargeScale = this.jumpChargeScale;
+    other.jumpPendingScale = this.jumpPendingScale;
+    other.previousJumpInput = this.previousJumpInput;
+    other.isJumping = this.isJumping;
+    other.allowStandSliding = this.allowStandSliding;
+    other.saddled = this.saddled;
+    other.worldReady = this.worldReady;
+    other.attributesReady = this.attributesReady;
+    other.riderYaw = this.riderYaw;
+    other.riderPitch = this.riderPitch;
+    other.age = this.age;
+    other.isCollidedHorizontally = this.isCollidedHorizontally;
+    other.isCollidedVertically = this.isCollidedVertically;
+    other.isInWater = this.isInWater;
+    other.isInLava = this.isInLava;
+    other.supportingBlockPos = this.supportingBlockPos?.clone() ?? null;
+    other.jumpBoost = this.jumpBoost;
+    return other;
+  }
+}

--- a/src/physics/states/horseState.ts
+++ b/src/physics/states/horseState.ts
@@ -192,9 +192,11 @@ export class HorseState extends EntityState {
     entity.pitch = this.pitch;
     entity.onGround = this.onGround;
     const entityExtras = entity as Entity & {
+      headYaw?: number;
       isCollidedHorizontally?: boolean;
       isCollidedVertically?: boolean;
     };
+    entityExtras.headYaw = this.yaw;
     entityExtras.isCollidedHorizontally = this.isCollidedHorizontally;
     entityExtras.isCollidedVertically = this.isCollidedVertically;
     return this;

--- a/src/physics/states/iEntityState.ts
+++ b/src/physics/states/iEntityState.ts
@@ -1,0 +1,51 @@
+import type { Effect, Entity } from "prismarine-entity";
+import type { Vec3 } from "vec3";
+import type { AABB } from "@nxg-org/mineflayer-util-plugin";
+import type { ControlStateHandler } from "../player/playerControls";
+import type { PlayerPoses } from "./poses";
+
+export interface IEntityState {
+  age: number;
+  height: number;
+  halfWidth: number;
+  pos: Vec3;
+  vel: Vec3;
+  pitch: number;
+  yaw: number;
+  pose: PlayerPoses;
+  control: ControlStateHandler;
+  onGround: boolean;
+  onClimbable: boolean;
+
+  attributes: Entity["attributes"];
+
+  isUsingItem: boolean;
+  isInWater: boolean;
+  isInLava: boolean;
+  isInWeb: boolean;
+  fallFlying: boolean;
+  elytraFlying: boolean;
+  validElytraEquipped: boolean;
+  fireworkRocketDuration: number;
+  sneakCollision: boolean;
+  isCollidedHorizontally: boolean;
+  isCollidedVertically: boolean;
+
+  effects: Effect[];
+  jumpBoost: number;
+  speed: number;
+  slowness: number;
+  dolphinsGrace: number;
+  slowFalling: number;
+  levitation: number;
+  depthStrider: number;
+
+  jumpTicks: number;
+  jumpQueued: boolean;
+
+  supportingBlockPos: Vec3 | null;
+
+  clone(): IEntityState;
+
+  getBB(): AABB;
+}

--- a/src/physics/states/index.ts
+++ b/src/physics/states/index.ts
@@ -1,66 +1,7 @@
-import type { Effect, Entity } from "prismarine-entity";
-import type {Vec3} from "vec3";
-import { PlayerPoses } from "./poses";
-import { ControlStateHandler } from "../states";
-import { AABB } from "@nxg-org/mineflayer-util-plugin";
-
-export * from "./entityState"
-export * from "./playerState"
-export * from "./poses"
-export * from "./boatState"
-
-export type Heading = {
-    forward: number;
-    strafe: number;
-}
-
-export interface IEntityState {
-    age: number;
-    height: number;
-    halfWidth: number;
-    pos: Vec3;
-    vel: Vec3;
-    pitch: number;
-    yaw: number;
-    pose: PlayerPoses;
-    control: ControlStateHandler;
-    onGround: boolean;
-    onClimbable: boolean;
-
-    attributes: Entity["attributes"];
-
-    isUsingItem: boolean;
-    isInWater: boolean;
-    isInLava: boolean;
-    isInWeb: boolean;
-    fallFlying: boolean;
-    elytraFlying: boolean;
-    validElytraEquipped: boolean;
-    fireworkRocketDuration: number;
-    sneakCollision: boolean;
-    isCollidedHorizontally: boolean;
-    isCollidedVertically: boolean;
-
-    effects: Effect[];
-    jumpBoost: number;
-    speed: number;
-    slowness: number;
-    dolphinsGrace: number;
-    slowFalling: number;
-    levitation: number;
-    depthStrider: number;
-
-    jumpTicks: number;
-    jumpQueued: boolean;
-
-    supportingBlockPos: Vec3 | null;
-
-    clone(): IEntityState;
-
-    getBB(): AABB;
-}
-
-export function getPose(entity: Entity) {
-    const pose = entity.metadata.find((e) => (e as any)?.type === 18);
-    return pose ? ((pose as any).value as number) : PlayerPoses.STANDING;
-}
+export * from "./entityState";
+export * from "./playerState";
+export * from "./poses";
+export * from "./boatState";
+export type { IEntityState } from "./iEntityState";
+export type { Heading } from "./entityPose";
+export { getPose } from "./entityPose";

--- a/src/physics/states/index.ts
+++ b/src/physics/states/index.ts
@@ -2,6 +2,7 @@ export * from "./entityState";
 export * from "./playerState";
 export * from "./poses";
 export * from "./boatState";
+export * from "./horseState";
 export type { IEntityState } from "./iEntityState";
 export type { Heading } from "./entityPose";
 export { getPose } from "./entityPose";

--- a/src/physics/states/playerState.ts
+++ b/src/physics/states/playerState.ts
@@ -15,11 +15,11 @@ import {
 // import { bot.entity } from "prismarine-entity";
 import md from "minecraft-data";
 import { ControlStateHandler } from "../player/playerControls";
-import { IEntityState } from ".";
+import { IEntityState } from "./iEntityState";
 import { IPhysics } from "../engines/IPhysics";
 import type { Entity } from "prismarine-entity";
 import { PlayerPoses, getCollider, playerPoseCtx } from "./poses";
-import { Heading, getPose } from ".";
+import { Heading, getPose } from "./entityPose";
 
 
 export function convInpToAxes(player: PlayerState): Heading {

--- a/src/util/physicsUtils.ts
+++ b/src/util/physicsUtils.ts
@@ -3,9 +3,10 @@ import { EPhysicsCtx } from "../physics/settings";
 import { AABB } from "@nxg-org/mineflayer-util-plugin";
 import features from "../physics/info/features.json";
 import md from "minecraft-data";
-import { ControlStateHandler, PlayerState } from "../physics/states";
+import { ControlStateHandler } from "../physics/player";
+import { PlayerState } from "../physics/states/playerState";
 import { Vec3 } from "vec3";
-import { IPhysics } from "../physics/engines";
+import { IPhysics } from "../physics/engines/IPhysics";
 import { Bot } from "mineflayer";
 
 export function makeSupportFeature(mcData: md.IndexedData) {

--- a/tests/helpers/unit/botcraftTestSupport.ts
+++ b/tests/helpers/unit/botcraftTestSupport.ts
@@ -4,9 +4,12 @@ import block, { Block as PBlock } from "prismarine-block";
 import { Vec3 } from "vec3";
 import { initSetup } from "../../../src";
 import { BotcraftPhysics, BoatPhysics } from "../../../src/physics/engines";
+import { HorsePhysics } from "../../../src/physics/engines/horsePhysics";
 import { ControlStateHandler } from "../../../src/physics/player";
 import { EPhysicsCtx } from "../../../src/physics/settings";
-import { BoatState, PlayerState } from "../../../src/physics/states";
+import { BoatState } from "../../../src/physics/states/boatState";
+import { HorseState } from "../../../src/physics/states/horseState";
+import { PlayerState } from "../../../src/physics/states/playerState";
 import { applyMdToNewEntity } from "../../../src/util/physicsUtils";
 import type { Entity } from "prismarine-entity";
 
@@ -164,6 +167,14 @@ export class BoatTestWorld {
     this.setBlock(pos, this.blocksByName.ice.id, 0);
   }
 
+  setFarmland(pos: Vec3) {
+    this.setBlock(pos, this.blocksByName.farmland.id, 0);
+  }
+
+  setLava(pos: Vec3, metadata = 0) {
+    this.setBlock(pos, this.blocksByName.lava.id, metadata);
+  }
+
   clearOverrides() {
     for (const key of Object.keys(this.overrideBlocks)) {
       delete this.overrideBlocks[key];
@@ -255,4 +266,56 @@ export function fillWaterColumn(world: BoatTestWorld, x: number, z: number, from
   for (let y = fromY; y <= toY; y++) {
     world.setWater(new Vec3(x, y, z), metadata);
   }
+}
+
+export function fillLavaColumn(world: BoatTestWorld, x: number, z: number, fromY: number, toY: number, metadata = 0) {
+  for (let y = fromY; y <= toY; y++) {
+    world.setLava(new Vec3(x, y, z), metadata);
+  }
+}
+
+export function createHorseRig(options: {
+  version: string;
+  position: Vec3;
+  floorY?: number;
+  entityName?: string;
+  attributes?: Record<string, { value: number; modifiers: Array<{ uuid: string; operation: number; amount: number }> }>;
+}) {
+  const { version, position } = options;
+  const entityName = options.entityName ?? "horse";
+  const floorY = options.floorY ?? Math.floor(position.y) - 1;
+  const { mcData } = loadMcData(version);
+
+  const physics = new HorsePhysics(mcData);
+  const entityDescriptor = mcData.entitiesByName[entityName];
+  const horseState = HorseState.CREATE_FROM_ENTITY(physics, {
+    position: position.clone(),
+    velocity: new Vec3(0, 0, 0),
+    yaw: 0,
+    pitch: 0,
+    height: entityDescriptor?.height,
+    width: entityDescriptor?.width,
+    onGround: true,
+    name: entityName,
+    attributes: options.attributes,
+  } as unknown as Entity);
+  horseState.control = ControlStateHandler.DEFAULT();
+
+  const horseCtx = EPhysicsCtx.FROM_ENTITY_STATE(physics, horseState, entityDescriptor);
+  horseCtx.stepHeight = 1.0;
+  const world = createBoatTestWorld(version, floorY);
+
+  return {
+    mcData,
+    physics,
+    horseState,
+    horseCtx,
+    world,
+    entityName,
+    entityDescriptor,
+  };
+}
+
+export function simulateHorseTick(rig: ReturnType<typeof createHorseRig>) {
+  rig.physics.simulate(rig.horseCtx, rig.world);
 }

--- a/tests/unit/horse/blockSupport.test.ts
+++ b/tests/unit/horse/blockSupport.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "mocha";
 import expect from "expect";
 import { Vec3 } from "vec3";
-import { resolveHorseSettings } from "../../../src/physics/settings/horseSettings";
+import { resolveHorseSettings, resolveWaterHorizontalSlowDown } from "../../../src/physics/settings/horseSettings";
 import {
   createHorseRig,
   loadMcData,
@@ -225,7 +225,7 @@ describe("HorsePhysics travel context", () => {
       airdrag: cfg.verticalDrag,
       airborneInertia: cfg.groundFrictionMultiplier,
       airborneAccel: Math.fround(0.225) * cfg.airborneAccelFactor,
-      waterInertia: cfg.waterInertia,
+      waterInertia: resolveWaterHorizontalSlowDown(rig171.horseState.species, loadMcData("1.17.1").mcData),
       lavaInertia: cfg.lavaHorizontalInertia,
       liquidAccel: cfg.liquidAccel,
       stepHeight: cfg.stepHeight,

--- a/tests/unit/horse/blockSupport.test.ts
+++ b/tests/unit/horse/blockSupport.test.ts
@@ -1,0 +1,241 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { resolveHorseSettings } from "../../../src/physics/settings/horseSettings";
+import {
+  createHorseRig,
+  loadMcData,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+function loadHorseBlockSupportModule() {
+  return require("../../../src/physics/settings/horseBlockSupport");
+}
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const { getHorseBlockBelowAffectingMovementPos, HORSE_BLOCK_BELOW_OFFSET_MODERN } =
+  loadHorseBlockSupportModule();
+
+/** Farmland collision top: blockY + 15/16. */
+const FARMLAND_SURFACE_Y = 63 + 15 / 16;
+const MODERN_OFFSET_Y = Math.fround(HORSE_BLOCK_BELOW_OFFSET_MODERN);
+
+function setupFarmlandOverIceRig(version: string) {
+  const rig = createHorseRig({
+    version,
+    position: new Vec3(0, FARMLAND_SURFACE_Y, 0),
+    floorY: 60,
+  });
+  rig.world.setIce(new Vec3(0, 62, 0));
+  rig.world.setFarmland(new Vec3(0, 63, 0));
+  rig.horseState.onGround = true;
+  rig.horseState.control.forward = true;
+  return rig;
+}
+
+function pickHorseTravelCtx(ctx: ReturnType<typeof createHorseRig>["horseCtx"]) {
+  return {
+    gravity: ctx.gravity,
+    waterGravity: ctx.waterGravity,
+    lavaGravity: ctx.lavaGravity,
+    airdrag: ctx.airdrag,
+    airborneInertia: ctx.airborneInertia,
+    airborneAccel: ctx.airborneAccel,
+    waterInertia: ctx.waterInertia,
+    lavaInertia: ctx.lavaInertia,
+    liquidAccel: ctx.liquidAccel,
+    stepHeight: ctx.stepHeight,
+    useControls: ctx.useControls,
+    gravityThenDrag: ctx.gravityThenDrag,
+    collisionBehavior: ctx.collisionBehavior,
+  };
+}
+
+describe("HorsePhysics block below feet", () => {
+  it("uses ice under farmland on 1.14.4 (legacy -1.0 offset)", () => {
+    const rig = setupFarmlandOverIceRig("1.14.4");
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.z).toBeCloseTo(-0.045128574939215405, 10);
+  });
+
+  it("uses farmland on 1.16.5 (0.5000001 offset)", () => {
+    const rig = setupFarmlandOverIceRig("1.16.5");
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.z).toBeCloseTo(-0.12039300448399745, 10);
+  });
+
+  it("picks different friction blocks between 1.14.4 and 1.16.5 on farmland", () => {
+    const legacy = setupFarmlandOverIceRig("1.14.4");
+    const modern = setupFarmlandOverIceRig("1.16.5");
+    simulateHorseTick(legacy);
+    simulateHorseTick(modern);
+    expect(legacy.horseState.vel.z).not.toBe(modern.horseState.vel.z);
+    expect(Math.abs(legacy.horseState.vel.z)).toBeLessThan(Math.abs(modern.horseState.vel.z));
+  });
+});
+
+describe("HorsePhysics block below feet — 1.20+ modern branch", () => {
+  const horsePos = new Vec3(0.65, FARMLAND_SURFACE_Y, 0);
+  const bbMinY = FARMLAND_SURFACE_Y;
+
+  function blockGetter(blocks: Record<string, { name: string; boundingBox: string }>) {
+    return (pos: Vec3) => blocks[`${pos.x},${pos.y},${pos.z}`] ?? null;
+  }
+
+  it("falls back to floor(minY - fround(0.500001)) without supportingBlockPos", () => {
+    const { mcData } = loadMcData("1.20.1");
+    const below = getHorseBlockBelowAffectingMovementPos(mcData, horsePos, bbMinY, null, () => null);
+    expect(below.x).toBe(Math.floor(horsePos.x));
+    expect(below.y).toBe(Math.floor(bbMinY - MODERN_OFFSET_Y));
+    expect(below.z).toBe(Math.floor(horsePos.z));
+  });
+
+  it("uses fround offset at pos.y boundary 64.500001 (vanilla floor gives 63, not 64)", () => {
+    const { mcData } = loadMcData("1.20.1");
+    const boundaryPos = new Vec3(0, 64.500001, 0);
+    const below = getHorseBlockBelowAffectingMovementPos(
+      mcData,
+      boundaryPos,
+      boundaryPos.y,
+      null,
+      () => null,
+    );
+    expect(below.y).toBe(63);
+    expect(below.y).toBe(Math.floor(boundaryPos.y - MODERN_OFFSET_Y));
+    expect(Math.floor(boundaryPos.y - HORSE_BLOCK_BELOW_OFFSET_MODERN)).toBe(64);
+  });
+
+  it("uses supportingBlockPos X/Z with recalculated Y for normal blocks", () => {
+    const { mcData, Block } = loadMcData("1.20.1");
+    const supporting = new Vec3(1, 63, 0);
+    const farmland = new Block(mcData.blocksByName.farmland.id, 0, 0);
+    farmland.name = "farmland";
+    farmland.boundingBox = "block";
+    const below = getHorseBlockBelowAffectingMovementPos(
+      mcData,
+      horsePos,
+      bbMinY,
+      supporting,
+      blockGetter({ "1,63,0": farmland }),
+    );
+    expect(below.x).toBe(1);
+    expect(below.y).toBe(Math.floor(horsePos.y - MODERN_OFFSET_Y));
+    expect(below.z).toBe(0);
+    expect(below.x).not.toBe(Math.floor(horsePos.x));
+  });
+
+  it("keeps supportingBlockPos unchanged for fence gate (vanilla gate branch)", () => {
+    const { mcData, Block } = loadMcData("1.20.1");
+    const supporting = new Vec3(1, 63, 0);
+    const gate = new Block(mcData.blocksByName.oak_fence_gate.id, 0, 0);
+    gate.name = "oak_fence_gate";
+    gate.boundingBox = "block";
+    const below = getHorseBlockBelowAffectingMovementPos(
+      mcData,
+      horsePos,
+      bbMinY,
+      supporting,
+      blockGetter({ "1,63,0": gate }),
+    );
+    expect(below).toEqual(supporting);
+  });
+
+  it("keeps supportingBlockPos unchanged for cobblestone wall", () => {
+    const { mcData, Block } = loadMcData("1.20.1");
+    const supporting = new Vec3(1, 63, 0);
+    const wall = new Block(mcData.blocksByName.cobblestone_wall.id, 0, 0);
+    wall.name = "cobblestone_wall";
+    wall.boundingBox = "block";
+    const below = getHorseBlockBelowAffectingMovementPos(
+      mcData,
+      horsePos,
+      bbMinY,
+      supporting,
+      blockGetter({ "1,63,0": wall }),
+    );
+    expect(below).toEqual(supporting);
+  });
+
+  it("uses farmland on 1.20.1 without supportingBlockPos (same as 1.16.5 offset)", () => {
+    const rig = setupFarmlandOverIceRig("1.20.1");
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.z).toBeCloseTo(-0.12039300448399745, 10);
+  });
+
+  it("uses supportingBlockPos farmland instead of ice at entity floored column", () => {
+    const rig = createHorseRig({
+      version: "1.20.1",
+      position: horsePos.clone(),
+      floorY: 60,
+    });
+    rig.world.setIce(new Vec3(0, 63, 0));
+    rig.world.setFarmland(new Vec3(1, 63, 0));
+    rig.horseState.supportingBlockPos = new Vec3(1, 63, 0);
+    rig.horseState.onGround = true;
+    rig.horseState.control.forward = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.z).toBeCloseTo(-0.12039300448399745, 10);
+
+    const withoutSupport = createHorseRig({
+      version: "1.20.1",
+      position: horsePos.clone(),
+      floorY: 60,
+    });
+    withoutSupport.world.setIce(new Vec3(0, 63, 0));
+    withoutSupport.world.setFarmland(new Vec3(1, 63, 0));
+    withoutSupport.horseState.onGround = true;
+    withoutSupport.horseState.control.forward = true;
+    simulateHorseTick(withoutSupport);
+    expect(withoutSupport.horseState.vel.z).toBeCloseTo(-0.045128574939215405, 10);
+  });
+});
+
+describe("HorsePhysics travel context", () => {
+  it("sets gravityThenDrag=true (living default; scoped travel ignores the flag)", () => {
+    const rig = createHorseRig({
+      version: "1.17.1",
+      position: new Vec3(0, 64, 0),
+      floorY: 63,
+    });
+    simulateHorseTick(rig);
+    expect(rig.horseCtx.gravityThenDrag).toBe(true);
+  });
+
+  it("applies identical horse travel ctx on 1.16.5 and 1.17.1", () => {
+    const rig165 = createHorseRig({
+      version: "1.16.5",
+      position: new Vec3(0, 64, 0),
+      floorY: 63,
+    });
+    const rig171 = createHorseRig({
+      version: "1.17.1",
+      position: new Vec3(0, 64, 0),
+      floorY: 63,
+    });
+
+    simulateHorseTick(rig165);
+    simulateHorseTick(rig171);
+
+    const cfg = resolveHorseSettings(loadMcData("1.17.1").mcData);
+    const expected = {
+      gravity: cfg.gravity,
+      waterGravity: cfg.gravity / 16,
+      lavaGravity: cfg.gravity / 4,
+      airdrag: cfg.verticalDrag,
+      airborneInertia: cfg.groundFrictionMultiplier,
+      airborneAccel: Math.fround(0.225) * cfg.airborneAccelFactor,
+      waterInertia: cfg.waterInertia,
+      lavaInertia: cfg.lavaHorizontalInertia,
+      liquidAccel: cfg.liquidAccel,
+      stepHeight: cfg.stepHeight,
+      useControls: false,
+      gravityThenDrag: true,
+      collisionBehavior: { blockEffects: true, affectedAfterCollision: true },
+    };
+
+    expect(pickHorseTravelCtx(rig165.horseCtx)).toEqual(expected);
+    expect(pickHorseTravelCtx(rig171.horseCtx)).toEqual(expected);
+    expect(pickHorseTravelCtx(rig165.horseCtx)).toEqual(pickHorseTravelCtx(rig171.horseCtx));
+  });
+});

--- a/tests/unit/horse/jump.test.ts
+++ b/tests/unit/horse/jump.test.ts
@@ -1,0 +1,367 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { HorseState } from "../../../src/physics/states/horseState";
+import {
+  createHorseRig,
+  fillWaterColumn,
+  loadMcData,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const groundY = 64;
+
+function setupGroundHorse() {
+  return createHorseRig({
+    version,
+    position: new Vec3(0, groundY, 0),
+    floorY: groundY - 1,
+    attributes: {
+      "generic.movement_speed": { value: 0.225, modifiers: [] },
+      "horse.jump_strength": { value: 0.7, modifiers: [] },
+    },
+  });
+}
+
+function setupLavaPool(horseY: number) {
+  const rig = createHorseRig({
+    version,
+    position: new Vec3(0, horseY, 0),
+    floorY: 61,
+  });
+  for (let x = -1; x <= 1; x++) {
+    for (let z = -1; z <= 1; z++) {
+      rig.world.setLava(new Vec3(x, 63, z), 0);
+    }
+  }
+  rig.horseState.vel.set(0, 0, 0);
+  rig.horseState.onGround = false;
+  return rig;
+}
+
+/** End-of-tick jump Y: executeRidersJump then air travel with float verticalDrag (1.17.1). */
+const VANILLA_JUMP_END_VEL_Y = (0.7 - 0.08) * Math.fround(0.98);
+const VANILLA_AIR_DROP_VEL_Y = (0 - 0.08) * Math.fround(0.98);
+const VANILLA_WATER_INERTIA = Math.fround(0.8);
+
+describe("HorsePhysics jump", () => {
+  it("starts at zero and charges linearly through the tenth held tick", () => {
+    const rig = setupGroundHorse();
+    for (let tick = 0; tick <= 10; tick++) {
+      rig.horseState.updateJumpCharge(true);
+      expect(rig.horseState.jumpChargeScale).toBeCloseTo(Math.min(tick * 0.1, 1), 5);
+    }
+  });
+
+  it("falls from 1.0 toward the vanilla 0.8 long-hold limit", () => {
+    const rig = setupGroundHorse();
+    for (let tick = 0; tick < 20; tick++) {
+      rig.horseState.updateJumpCharge(true);
+    }
+    expect(rig.horseState.jumpChargeScale).toBeGreaterThan(0.8);
+    expect(rig.horseState.jumpChargeScale).toBeLessThan(0.9);
+  });
+
+  it("sets pending scale on release with minimum 0.4 for quick tap", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.updateJumpCharge(true);
+    const release = rig.horseState.updateJumpCharge(false);
+    expect(release.released).toBe(true);
+    expect(release.jumpBoost).toBe(0);
+    expect(rig.horseState.jumpPendingScale).toBeCloseTo(0.4, 5);
+  });
+
+  it("applies vanilla end-of-tick jump Y for scale 1.0", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.jumpPendingScale = 1.0;
+    rig.horseState.onGround = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBe(VANILLA_JUMP_END_VEL_Y);
+  });
+
+  it("assigns jump Y directly without Math.max regression", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.vel.y = 1.2;
+    rig.horseState.jumpPendingScale = 1.0;
+    rig.horseState.onGround = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBe(VANILLA_JUMP_END_VEL_Y);
+    expect(rig.horseState.vel.y).toBeLessThan(1.0);
+  });
+
+  it("adds forward horizontal impulse when jumping forward", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.control.forward = true;
+    rig.horseState.jumpPendingScale = 1.0;
+    rig.horseState.onGround = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.z).toBeLessThan(0);
+    expect(rig.horseState.vel.y).toBe(VANILLA_JUMP_END_VEL_Y);
+  });
+
+  it("lands and allows repeated jumps", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.jumpPendingScale = 1.0;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBeGreaterThan(0);
+
+    for (let i = 0; i < 30; i++) simulateHorseTick(rig);
+    expect(rig.horseState.onGround).toBe(true);
+
+    rig.horseState.jumpPendingScale = 0.5;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBeGreaterThan(0);
+  });
+
+  it("uses honey block jump factor", () => {
+    const rig = setupGroundHorse();
+    const honeyId = rig.mcData.blocksByName.honey_block?.id;
+    if (honeyId != null) {
+      rig.world.setBlock(new Vec3(0, groundY, 0), honeyId);
+    }
+    rig.horseState.jumpPendingScale = 1.0;
+    simulateHorseTick(rig);
+    const honeyJump = rig.horseState.vel.y;
+
+    const normalRig = setupGroundHorse();
+    normalRig.horseState.jumpPendingScale = 1.0;
+    simulateHorseTick(normalRig);
+    if (honeyId != null) {
+      expect(honeyJump).toBeLessThan(normalRig.horseState.vel.y);
+    }
+  });
+
+  it("reads jump strength from entity attributes", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+      attributes: {
+        "horse.jump_strength": { value: 1.0, modifiers: [] },
+      },
+    });
+    expect(rig.horseState.jumpStrength).toBeCloseTo(1.0, 5);
+  });
+
+  it("clone preserves jump state independently", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.jumpChargeScale = 0.5;
+    rig.horseState.jumpPendingScale = 0.8;
+    const clone = rig.horseState.clone();
+    clone.jumpChargeScale = 0.1;
+    expect(rig.horseState.jumpChargeScale).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe("HorseState attributes", () => {
+  it("applies attribute modifiers without mutating source", () => {
+    const attr = {
+      value: 0.225,
+      modifiers: [{ uuid: "test", operation: 1, amount: 0.5 }],
+    };
+    const speed = HorseState.getMovementSpeedFromAttributes(
+      { "generic.movement_speed": attr },
+      loadMcData("1.17.1").mcData,
+    );
+    expect(speed).toBeCloseTo(0.3375, 4);
+    expect(attr.modifiers.length).toBe(1);
+  });
+});
+
+describe("HorsePhysics travel — water and lava oracle", () => {
+  it("applies drag-then-gravity water branch with float waterInertia", () => {
+    const waterY = 64;
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, waterY - 0.5, 0),
+      floorY: waterY - 3,
+    });
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -1; z <= 1; z++) {
+        fillWaterColumn(rig.world, x, z, waterY - 1, waterY, 0);
+      }
+    }
+    rig.horseState.vel.set(0, 0, 0);
+    rig.horseState.onGround = false;
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInWater).toBe(true);
+    expect(rig.horseState.vel.y).toBe(-0.005);
+  });
+
+  it("applies float waterInertia to non-zero vertical velocity", () => {
+    const waterY = 64;
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, waterY - 0.5, 0),
+      floorY: waterY - 3,
+    });
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -1; z <= 1; z++) {
+        fillWaterColumn(rig.world, x, z, waterY - 1, waterY, 0);
+      }
+    }
+    rig.horseState.vel.set(0, 0.5, 0);
+    rig.horseState.onGround = false;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBe(0.5 * VANILLA_WATER_INERTIA - 0.005);
+  });
+
+  it("detects lava when feet are below source surface (y≈63.85)", () => {
+    const rig = setupLavaPool(63.85);
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(true);
+    expect(rig.horseState.vel.y).toBe(-0.025);
+  });
+
+  it("does not detect lava when feet are above source surface (y=63.9)", () => {
+    const rig = setupLavaPool(63.9);
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(false);
+    expect(rig.horseState.vel.y).toBe(VANILLA_AIR_DROP_VEL_Y);
+  });
+
+  it("applies deep lava branch when submerged", () => {
+    const rig = setupLavaPool(63.1);
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(true);
+    expect(rig.horseState.vel.y).toBe(-0.02);
+  });
+
+  it("parses string lava level from block properties", () => {
+    const rig = setupLavaPool(63.85);
+    const block = rig.world.getBlock(new Vec3(0, 63, 0));
+    expect(typeof block?.getProperties().level).toBe("string");
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(true);
+  });
+
+  it("detects lava while falling with negative Y velocity", () => {
+    const rig = setupLavaPool(63.85);
+    rig.horseState.vel.y = -0.5;
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(true);
+  });
+
+  it("detects lava at horizontal BB edge with vanilla deflate BB", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0.65, 63.85, 0),
+      floorY: 61,
+    });
+    rig.world.setLava(new Vec3(1, 63, 0), 0);
+    rig.horseState.vel.set(0, -0.2, 0);
+    rig.horseState.onGround = false;
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(true);
+  });
+
+  it("detects lava when fluidTop equals deflated BB minY (fluidTop >= bb.minY)", () => {
+    const surfaceY = 63 + 8 / 9;
+    // Feet one millimeter below surface so deflate(0.001) minY equals fluidTop.
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, surfaceY - 0.001, 0),
+      floorY: 61,
+    });
+    rig.world.setLava(new Vec3(0, 63, 0), 0);
+    rig.horseState.vel.set(0, 0, 0);
+    rig.horseState.onGround = false;
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(true);
+  });
+});
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+function loadHorseJumpPrecisionModule() {
+  return require("../../../src/physics/settings/horseSettings");
+}
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+describe("HorsePhysics jump precision", () => {
+  const {
+    computeChargeScale,
+    computePendingJumpScale,
+    computeHorseJumpPower,
+    computeJumpBoostPower,
+    floorRidingChargeIndex,
+  } = loadHorseJumpPrecisionModule();
+
+  it("floors riding charge index from float32 scale product at tick 7", () => {
+    expect(floorRidingChargeIndex(computeChargeScale(7))).toBe(70);
+  });
+
+  it("uses sequential float32 pending scale for charge index 8", () => {
+    const vanilla = computePendingJumpScale(8);
+    const simplified = Math.fround(0.4 + 0.4 * (8 / 90));
+    expect(vanilla).toBe(0.4355555772781372);
+    expect(vanilla).not.toBe(simplified);
+  });
+
+  it("uses sequential float32 pending scale for charge index 2", () => {
+    const vanilla = computePendingJumpScale(2);
+    const simplified = Math.fround(0.4 + 0.4 * (2 / 90));
+    expect(vanilla).toBe(0.40888890624046326);
+    expect(vanilla).not.toBe(simplified);
+  });
+
+  it("matches vanilla charge scale at tick 2", () => {
+    expect(computeChargeScale(2)).toBe(0.20000000298023224);
+  });
+
+  it("derives pending scale from riding charge index on release", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.jumpChargeScale = 0.025;
+    rig.horseState.previousJumpInput = true;
+    rig.horseState.updateJumpCharge(false);
+    expect(rig.horseState.jumpPendingScale).toBe(computePendingJumpScale(2));
+  });
+
+  it("applies full float32 getJumpPower chain on 1.21.1 for scale 0.4", () => {
+    const { mcData } = loadMcData("1.21.1");
+    const jumpPower = computeHorseJumpPower(0.7, 0.4, 1.0, 0, mcData);
+    expect(jumpPower).toBe(0.2800000011920929);
+    expect(jumpPower).not.toBe(0.28);
+
+    const rig = createHorseRig({
+      version: "1.21.1",
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+      attributes: {
+        "generic.movement_speed": { value: 0.225, modifiers: [] },
+        "generic.jump_strength": { value: 0.7, modifiers: [] },
+      },
+    });
+    rig.horseState.jumpPendingScale = 0.4;
+    rig.horseState.onGround = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBe((jumpPower - 0.08) * Math.fround(0.98));
+  });
+
+  it("uses double jump power chain on 1.17.1 for scale 0.4", () => {
+    const { mcData } = loadMcData("1.17.1");
+    const jumpPower = computeHorseJumpPower(0.7, 0.4, 1.0, 0, mcData);
+    expect(jumpPower).toBe(0.27999999999999997);
+
+    const rig = setupGroundHorse();
+    rig.horseState.jumpPendingScale = 0.4;
+    rig.horseState.onGround = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBe((jumpPower - 0.08) * Math.fround(0.98));
+  });
+
+  it("applies float32 jump boost power from potion level", () => {
+    const { mcData } = loadMcData("1.17.1");
+    expect(computeJumpBoostPower(2)).toBe(0.20000000298023224);
+
+    const jumpPower = computeHorseJumpPower(0.7, 1.0, 1.0, 2, mcData);
+    expect(jumpPower).toBe(0.9000000029802322);
+
+    const rig = setupGroundHorse();
+    rig.horseState.jumpPendingScale = 1.0;
+    rig.horseState.jumpBoost = 2;
+    rig.horseState.onGround = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.y).toBe((jumpPower - 0.08) * Math.fround(0.98));
+  });
+});

--- a/tests/unit/horse/jump.test.ts
+++ b/tests/unit/horse/jump.test.ts
@@ -43,7 +43,8 @@ function setupLavaPool(horseY: number) {
 /** End-of-tick jump Y: executeRidersJump then air travel with float verticalDrag (1.17.1). */
 const VANILLA_JUMP_END_VEL_Y = (0.7 - 0.08) * Math.fround(0.98);
 const VANILLA_AIR_DROP_VEL_Y = (0 - 0.08) * Math.fround(0.98);
-const VANILLA_WATER_INERTIA = Math.fround(0.8);
+const VANILLA_WATER_VERTICAL_INERTIA = Math.fround(0.8);
+const VANILLA_SKELETON_WATER_HORIZONTAL = Math.fround(0.96);
 
 describe("HorsePhysics jump", () => {
   it("starts at zero and charges linearly through the tenth held tick", () => {
@@ -152,6 +153,20 @@ describe("HorsePhysics jump", () => {
     clone.jumpChargeScale = 0.1;
     expect(rig.horseState.jumpChargeScale).toBeCloseTo(0.5, 5);
   });
+
+  it("clone preserves species", () => {
+    const rig = createHorseRig({
+      version,
+      entityName: "skeleton_horse",
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    expect(rig.horseState.species).toBe("skeleton_horse");
+    const clone = rig.horseState.clone();
+    expect(clone.species).toBe("skeleton_horse");
+    clone.species = "horse";
+    expect(rig.horseState.species).toBe("skeleton_horse");
+  });
 });
 
 describe("HorseState attributes", () => {
@@ -170,7 +185,25 @@ describe("HorseState attributes", () => {
 });
 
 describe("HorsePhysics travel — water and lava oracle", () => {
-  it("applies drag-then-gravity water branch with float waterInertia", () => {
+  function setupWaterHorse(entityName = "horse") {
+    const waterY = 64;
+    const rig = createHorseRig({
+      version,
+      entityName,
+      position: new Vec3(0, waterY - 0.5, 0),
+      floorY: waterY - 3,
+    });
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -1; z <= 1; z++) {
+        fillWaterColumn(rig.world, x, z, waterY - 1, waterY, 0);
+      }
+    }
+    rig.horseState.vel.set(1.0, 0.5, -0.3);
+    rig.horseState.onGround = false;
+    return rig;
+  }
+
+  it("applies drag-then-gravity water branch with float liquidVerticalInertia", () => {
     const waterY = 64;
     const rig = createHorseRig({
       version,
@@ -189,7 +222,7 @@ describe("HorsePhysics travel — water and lava oracle", () => {
     expect(rig.horseState.vel.y).toBe(-0.005);
   });
 
-  it("applies float waterInertia to non-zero vertical velocity", () => {
+  it("applies float liquidVerticalInertia to non-zero vertical velocity", () => {
     const waterY = 64;
     const rig = createHorseRig({
       version,
@@ -204,7 +237,35 @@ describe("HorsePhysics travel — water and lava oracle", () => {
     rig.horseState.vel.set(0, 0.5, 0);
     rig.horseState.onGround = false;
     simulateHorseTick(rig);
-    expect(rig.horseState.vel.y).toBe(0.5 * VANILLA_WATER_INERTIA - 0.005);
+    expect(rig.horseState.vel.y).toBe(0.5 * VANILLA_WATER_VERTICAL_INERTIA - 0.005);
+  });
+
+  it("applies species-specific horizontal water slowdown for skeleton horse", () => {
+    const rig = setupWaterHorse("skeleton_horse");
+    simulateHorseTick(rig);
+    expect(rig.horseState.species).toBe("skeleton_horse");
+    expect(rig.horseState.vel.x).toBe(1.0 * VANILLA_SKELETON_WATER_HORIZONTAL);
+    expect(rig.horseState.vel.y).toBe(0.5 * VANILLA_WATER_VERTICAL_INERTIA - 0.005);
+    expect(rig.horseState.vel.z).toBe(-0.3 * VANILLA_SKELETON_WATER_HORIZONTAL);
+  });
+
+  it("applies default horizontal water slowdown for ordinary horse", () => {
+    const rig = setupWaterHorse("horse");
+    simulateHorseTick(rig);
+    expect(rig.horseState.vel.x).toBe(1.0 * VANILLA_WATER_VERTICAL_INERTIA);
+    expect(rig.horseState.vel.y).toBe(0.5 * VANILLA_WATER_VERTICAL_INERTIA - 0.005);
+    expect(rig.horseState.vel.z).toBe(-0.3 * VANILLA_WATER_VERTICAL_INERTIA);
+  });
+
+  it("uses liquidVerticalInertia for skeleton horse shallow lava Y drag", () => {
+    const rig = setupLavaPool(63.85);
+    rig.horseState.species = "skeleton_horse";
+    rig.horseState.vel.set(1.0, 0.5, -0.3);
+    simulateHorseTick(rig);
+    expect(rig.horseState.isInLava).toBe(true);
+    expect(rig.horseState.vel.x).toBe(0.5);
+    expect(rig.horseState.vel.y).toBe(0.5 * VANILLA_WATER_VERTICAL_INERTIA - 0.005 - 0.02);
+    expect(rig.horseState.vel.z).toBe(-0.15);
   });
 
   it("detects lava when feet are below source surface (y≈63.85)", () => {

--- a/tests/unit/horse/movement.test.ts
+++ b/tests/unit/horse/movement.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import {
+  createHorseRig,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const groundY = 64;
+
+function setupGroundHorse() {
+  return createHorseRig({
+    version,
+    position: new Vec3(0, groundY, 0),
+    floorY: groundY - 1,
+  });
+}
+
+describe("HorsePhysics movement", () => {
+  it("moves forward when forward control is pressed", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.control.forward = true;
+    for (let i = 0; i < 5; i++) simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeLessThan(0);
+  });
+
+  it("moves backward slower than forward", () => {
+    const forwardRig = setupGroundHorse();
+    forwardRig.horseState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(forwardRig);
+    const forwardDistance = Math.hypot(forwardRig.horseState.pos.x, forwardRig.horseState.pos.z);
+
+    const backRig = setupGroundHorse();
+    backRig.horseState.control.back = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(backRig);
+    const backDistance = Math.hypot(backRig.horseState.pos.x, backRig.horseState.pos.z);
+
+    expect(forwardDistance).toBeGreaterThan(backDistance * 2);
+  });
+
+  it("strafes left and right with opposite X deltas", () => {
+    const leftRig = setupGroundHorse();
+    leftRig.horseState.control.left = true;
+    simulateHorseTick(leftRig);
+    const leftX = leftRig.horseState.pos.x;
+
+    const rightRig = setupGroundHorse();
+    rightRig.horseState.control.right = true;
+    simulateHorseTick(rightRig);
+    const rightX = rightRig.horseState.pos.x;
+
+    expect(leftX).toBeLessThan(0);
+    expect(rightX).toBeGreaterThan(0);
+  });
+
+  it("uses rider yaw for horse rotation", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.updateControls(rig.horseState.control, Math.PI / 2, 0);
+    expect(rig.horseState.yaw).toBeCloseTo(Math.PI / 2, 5);
+  });
+
+  it("sets horse pitch to half rider pitch", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.updateControls(rig.horseState.control, 0, Math.PI / 4);
+    expect(rig.horseState.pitch).toBeCloseTo(Math.PI / 8, 5);
+  });
+
+  it("does not apply sprint speed multiplier", () => {
+    const normalRig = setupGroundHorse();
+    normalRig.horseState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(normalRig);
+    const normalDistance = Math.hypot(normalRig.horseState.pos.x, normalRig.horseState.pos.z);
+
+    const sprintRig = setupGroundHorse();
+    sprintRig.horseState.control.forward = true;
+    sprintRig.horseState.control.sprint = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(sprintRig);
+    const sprintDistance = Math.hypot(sprintRig.horseState.pos.x, sprintRig.horseState.pos.z);
+
+    expect(Math.abs(sprintDistance - normalDistance)).toBeLessThan(0.01);
+  });
+
+  it("steps up a 1-block ledge", () => {
+    const rig = setupGroundHorse();
+    for (let x = -2; x <= 2; x++) {
+      for (let z = -2; z <= 5; z++) {
+        rig.world.setStone(new Vec3(x, groundY - 1, z));
+      }
+    }
+    rig.world.setStone(new Vec3(0, groundY, -3));
+    rig.horseState.control.forward = true;
+    let maxY = rig.horseState.pos.y;
+    for (let i = 0; i < 20; i++) {
+      simulateHorseTick(rig);
+      maxY = Math.max(maxY, rig.horseState.pos.y);
+    }
+    expect(maxY).toBeGreaterThanOrEqual(groundY + 1);
+  });
+
+  it("collides with a wall", () => {
+    const rig = setupGroundHorse();
+    for (let y = groundY - 1; y <= groundY + 2; y++) {
+      rig.world.setStone(new Vec3(0, y, -3));
+    }
+    rig.horseState.control.forward = true;
+    for (let i = 0; i < 30; i++) simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeGreaterThan(-2.5);
+  });
+
+  it("moves faster on ice than stone", () => {
+    const iceRig = setupGroundHorse();
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -20; z <= 1; z++) {
+        iceRig.world.setIce(new Vec3(x, groundY - 1, z));
+      }
+    }
+    iceRig.horseState.control.forward = true;
+    for (let i = 0; i < 20; i++) simulateHorseTick(iceRig);
+    const iceSpeed = Math.hypot(iceRig.horseState.vel.x, iceRig.horseState.vel.z);
+
+    const stoneRig = setupGroundHorse();
+    stoneRig.horseState.control.forward = true;
+    for (let i = 0; i < 20; i++) simulateHorseTick(stoneRig);
+    const stoneSpeed = Math.hypot(stoneRig.horseState.vel.x, stoneRig.horseState.vel.z);
+
+    expect(iceSpeed).toBeGreaterThan(stoneSpeed);
+  });
+});

--- a/tests/unit/horse/movement.test.ts
+++ b/tests/unit/horse/movement.test.ts
@@ -127,3 +127,62 @@ describe("HorsePhysics movement", () => {
     expect(iceSpeed).toBeGreaterThan(stoneSpeed);
   });
 });
+
+describe("HorsePhysics diagonal input normalization", () => {
+  it("leaves forward-only acceleration unchanged", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.control.forward = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeCloseTo(-0.22049999309579482, 10);
+    expect(rig.horseState.vel.z).toBeCloseTo(-0.12039300448399745, 10);
+  });
+
+  it("normalizes forward+strafe input like Entity#getInputVector", () => {
+    const forwardRig = setupGroundHorse();
+    forwardRig.horseState.control.forward = true;
+    forwardRig.horseState.vel.set(0, 0, 0);
+    simulateHorseTick(forwardRig);
+    const forwardDelta = Math.hypot(forwardRig.horseState.vel.x, forwardRig.horseState.vel.z);
+
+    const diagRig = setupGroundHorse();
+    diagRig.horseState.control.forward = true;
+    diagRig.horseState.control.left = true;
+    diagRig.horseState.vel.set(0, 0, 0);
+    simulateHorseTick(diagRig);
+    const diagDelta = Math.hypot(diagRig.horseState.vel.x, diagRig.horseState.vel.z);
+
+    const unnormalizedRatio = Math.sqrt(1.2005);
+    expect(diagDelta).toBeGreaterThan(forwardDelta);
+    expect(diagDelta / forwardDelta).toBeCloseTo(1 / 0.98, 5);
+    expect(diagDelta).toBeLessThan(unnormalizedRatio * forwardDelta);
+  });
+
+  it("applies unit-length diagonal acceleration magnitude", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.control.forward = true;
+    rig.horseState.control.left = true;
+    rig.horseState.vel.set(0, 0, 0);
+    simulateHorseTick(rig);
+
+    const groundFriction = 0.6;
+    const horizontalFriction = groundFriction * 0.91;
+    const acceleration =
+      rig.horseState.movementSpeed *
+      (0.21600002 / (groundFriction * groundFriction * groundFriction));
+    const horizVel = Math.hypot(rig.horseState.vel.x, rig.horseState.vel.z);
+
+    expect(horizVel / horizontalFriction).toBeCloseTo(acceleration, 7);
+    expect(horizVel / horizontalFriction).toBeLessThan(Math.sqrt(1.2005) * acceleration);
+  });
+
+  it("does not produce NaN or movement for zero input", () => {
+    const rig = setupGroundHorse();
+    rig.horseState.vel.set(0, 0, 0);
+    simulateHorseTick(rig);
+    expect(Number.isNaN(rig.horseState.vel.x)).toBe(false);
+    expect(Number.isNaN(rig.horseState.vel.y)).toBe(false);
+    expect(Number.isNaN(rig.horseState.vel.z)).toBe(false);
+    expect(rig.horseState.vel.x).toBe(0);
+    expect(rig.horseState.vel.z).toBe(0);
+  });
+});

--- a/tests/unit/horse/multiversion.test.ts
+++ b/tests/unit/horse/multiversion.test.ts
@@ -1,0 +1,222 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import {
+  createHorseRig,
+  loadMcData,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+function loadHorseSettingsModule() {
+  return require("../../../src/physics/settings/horseSettings");
+}
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const groundY = 64;
+
+const versions = [
+  {
+    version: "1.14.4",
+    entityNames: ["horse", "donkey"],
+    movementKey: "generic.movementSpeed",
+    jumpKey: "horse.jumpStrength",
+    movementValue: 0.33,
+    jumpValue: 0.55,
+  },
+  {
+    version: "1.16.5",
+    entityNames: ["horse", "mule"],
+    movementKey: "generic.movement_speed",
+    jumpKey: "horse.jump_strength",
+    movementValue: 0.31,
+    jumpValue: 0.45,
+  },
+  {
+    version: "1.17.1",
+    entityNames: ["horse", "skeleton_horse", "zombie_horse"],
+    movementKey: "generic.movement_speed",
+    jumpKey: "horse.jump_strength",
+    movementValue: 0.29,
+    jumpValue: 0.85,
+  },
+  {
+    version: "1.20.1",
+    entityNames: ["horse", "donkey"],
+    movementKey: "generic.movement_speed",
+    jumpKey: "horse.jump_strength",
+    movementValue: 0.27,
+    jumpValue: 0.65,
+  },
+  {
+    version: "1.21.1",
+    entityNames: ["horse"],
+    movementKey: "generic.movement_speed",
+    jumpKey: "generic.jump_strength",
+    movementValue: 0.25,
+    jumpValue: 0.75,
+  },
+  {
+    version: "1.21.4",
+    entityNames: ["horse", "donkey"],
+    movementKey: "generic.movement_speed",
+    jumpKey: "generic.jump_strength",
+    movementValue: 0.23,
+    jumpValue: 0.95,
+  },
+  {
+    version: "1.21.11",
+    entityNames: ["horse", "donkey"],
+    movementKey: "generic.movement_speed",
+    jumpKey: "generic.jump_strength",
+    movementValue: 0.21,
+    jumpValue: 0.35,
+  },
+];
+
+function expectHorseLivingContext(rig: ReturnType<typeof createHorseRig>) {
+  expect(rig.horseCtx.stepHeight).toBe(1.0);
+  simulateHorseTick(rig);
+  expect(rig.horseCtx.useControls).toBe(false);
+  expect(rig.horseCtx.gravity).toBe(0.08);
+  expect(rig.horseCtx.collisionBehavior).toEqual({
+    blockEffects: true,
+    affectedAfterCollision: true,
+  });
+}
+
+describe("HorsePhysics multiversion compatibility", () => {
+  for (const {
+    version,
+    entityNames,
+    movementKey,
+    jumpKey,
+    movementValue,
+    jumpValue,
+  } of versions) {
+    describe(version, () => {
+      for (const entityName of entityNames) {
+        describe(entityName, () => {
+          it("resolves entity descriptor and dimensions", () => {
+            const rig = createHorseRig({
+              version,
+              entityName,
+              position: new Vec3(0, groundY, 0),
+              floorY: groundY - 1,
+            });
+
+            expect(rig.entityDescriptor).toBe(rig.mcData.entitiesByName[entityName]);
+            expect(rig.horseState.height).toBe(rig.entityDescriptor.height);
+            expect(rig.horseState.halfWidth * 2).toBe(rig.entityDescriptor.width);
+          });
+
+          it("uses living-entity collision context with horse step height", () => {
+            const rig = createHorseRig({
+              version,
+              entityName,
+              position: new Vec3(0, groundY, 0),
+              floorY: groundY - 1,
+            });
+            expectHorseLivingContext(rig);
+          });
+
+          it("reads movement and jump attributes from real packet keys", () => {
+            const rig = createHorseRig({
+              version,
+              entityName,
+              position: new Vec3(0, groundY, 0),
+              floorY: groundY - 1,
+              attributes: {
+                [movementKey]: { value: movementValue, modifiers: [] },
+                [jumpKey]: { value: jumpValue, modifiers: [] },
+              },
+            });
+
+            expect(rig.horseState.movementSpeed).toBeCloseTo(movementValue, 5);
+            expect(rig.horseState.jumpStrength).toBeCloseTo(jumpValue, 5);
+          });
+
+          it("moves forward under forward input", () => {
+            const rig = createHorseRig({
+              version,
+              entityName,
+              position: new Vec3(0, groundY, 0),
+              floorY: groundY - 1,
+            });
+            rig.horseState.control.forward = true;
+            simulateHorseTick(rig);
+            expect(rig.horseState.pos.z).toBeLessThan(0);
+          });
+
+          it("keeps finite state after repeated ticks", () => {
+            const rig = createHorseRig({
+              version,
+              entityName,
+              position: new Vec3(0, groundY, 0),
+              floorY: groundY - 1,
+            });
+            rig.horseState.control.forward = true;
+            for (let i = 0; i < 20; i++) {
+              simulateHorseTick(rig);
+              expect(Number.isFinite(rig.horseState.pos.x)).toBe(true);
+              expect(Number.isFinite(rig.horseState.pos.y)).toBe(true);
+              expect(Number.isFinite(rig.horseState.pos.z)).toBe(true);
+              expect(Number.isFinite(rig.horseState.vel.x)).toBe(true);
+              expect(Number.isFinite(rig.horseState.vel.y)).toBe(true);
+              expect(Number.isFinite(rig.horseState.vel.z)).toBe(true);
+            }
+          });
+        });
+      }
+    });
+  }
+});
+
+describe("HorsePhysics attribute key matrix", () => {
+  it("reads 1.14.4 camelCase movementSpeed key", () => {
+    const { getHorseMovementSpeedAttribute } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.14.4");
+    const speed = getHorseMovementSpeedAttribute(
+      { "generic.movementSpeed": { value: 0.42, modifiers: [] } },
+      mcData,
+    );
+    expect(speed).toBeCloseTo(0.42, 5);
+  });
+
+  it("reads 1.21.x generic.jump_strength packet key", () => {
+    const { getHorseJumpStrengthAttribute } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.21.1");
+    const jump = getHorseJumpStrengthAttribute(
+      { "generic.jump_strength": { value: 0.88, modifiers: [] } },
+      mcData,
+    );
+    expect(jump).toBeCloseTo(0.88, 5);
+  });
+
+  it("falls back to defaults when no attribute key matches", () => {
+    const { getHorseMovementSpeedAttribute, getHorseJumpStrengthAttribute } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    expect(getHorseMovementSpeedAttribute({}, mcData)).toBeCloseTo(0.225, 5);
+    expect(getHorseJumpStrengthAttribute({}, mcData)).toBe(0.7);
+  });
+
+  it("applies float jump strength precision from 1.21+", () => {
+    const { applyJumpStrengthPrecision, usesFloatJumpStrengthPrecision } = loadHorseSettingsModule();
+    const mcData17 = loadMcData("1.17.1").mcData;
+    const mcData21 = loadMcData("1.21.1").mcData;
+    expect(usesFloatJumpStrengthPrecision(mcData17)).toBe(false);
+    expect(usesFloatJumpStrengthPrecision(mcData21)).toBe(true);
+    expect(applyJumpStrengthPrecision(0.7, mcData17)).toBe(0.7);
+    expect(applyJumpStrengthPrecision(0.7, mcData21)).toBe(Math.fround(0.7));
+  });
+
+  it("casts movement speed to float like getRiddenSpeed", () => {
+    const { applyMovementSpeedPrecision, getHorseMovementSpeedAttribute } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const speed = getHorseMovementSpeedAttribute(
+      { "generic.movement_speed": { value: 0.225, modifiers: [] } },
+      mcData,
+    );
+    expect(speed).toBe(applyMovementSpeedPrecision(0.225));
+  });
+});

--- a/tests/unit/horse/multiversion.test.ts
+++ b/tests/unit/horse/multiversion.test.ts
@@ -166,6 +166,21 @@ describe("HorsePhysics multiversion compatibility", () => {
               expect(Number.isFinite(rig.horseState.vel.z)).toBe(true);
             }
           });
+
+          if (version === "1.17.1" && entityName === "skeleton_horse") {
+            it("resolves skeleton horse horizontal water slowdown", () => {
+              const { resolveWaterHorizontalSlowDown } = loadHorseSettingsModule();
+              const rig = createHorseRig({
+                version,
+                entityName,
+                position: new Vec3(0, groundY, 0),
+                floorY: groundY - 1,
+              });
+              expect(rig.horseState.species).toBe("skeleton_horse");
+              expect(resolveWaterHorizontalSlowDown("skeleton_horse", rig.mcData)).toBe(Math.fround(0.96));
+              expect(resolveWaterHorizontalSlowDown("horse", rig.mcData)).toBe(Math.fround(0.8));
+            });
+          }
         });
       }
     });

--- a/tests/unit/horse/settings.test.ts
+++ b/tests/unit/horse/settings.test.ts
@@ -38,7 +38,8 @@ describe("Horse settings resolution", () => {
     expect(resolved.defaultJumpStrength).toBe(defaultSettings.defaultJumpStrength);
     expect(resolved.defaultJumpStrength).toBe(0.7);
     expect(resolved.verticalDrag).toBe(Math.fround(defaultSettings.verticalDrag));
-    expect(resolved.waterInertia).toBe(Math.fround(defaultSettings.waterInertia));
+    expect(resolved.liquidVerticalInertia).toBe(Math.fround(defaultSettings.liquidVerticalInertia));
+    expect(resolved.waterHorizontalSlowDown).toBe(Math.fround(defaultSettings.waterHorizontalSlowDown));
     expect(resolved.lavaShallowThreshold).toBe(defaultSettings.lavaShallowThreshold);
   });
 
@@ -90,6 +91,14 @@ describe("Horse settings resolution", () => {
 
     const resolved = resolveHorseSettingsFromSection(mcData, testSection);
     expect(resolved.defaultMovementSpeed).toBe(Math.fround(0.2));
+  });
+
+  it("resolves skeleton horse horizontal water slowdown via speciesOverrides", () => {
+    const { resolveWaterHorizontalSlowDown } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    expect(resolveWaterHorizontalSlowDown("horse", mcData)).toBe(Math.fround(0.8));
+    expect(resolveWaterHorizontalSlowDown("skeleton_horse", mcData)).toBe(Math.fround(0.96));
+    expect(resolveWaterHorizontalSlowDown("donkey", mcData)).toBe(Math.fround(0.8));
   });
 });
 

--- a/tests/unit/horse/settings.test.ts
+++ b/tests/unit/horse/settings.test.ts
@@ -1,0 +1,263 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import { HorseState } from "../../../src/physics/states/horseState";
+import {
+  createHorseRig,
+  loadMcData,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+function loadHorseSettingsModule() {
+  return require("../../../src/physics/settings/horseSettings");
+}
+
+function loadHorseSettingsJson() {
+  return require("../../../src/physics/info/entity_physics.json");
+}
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const version = "1.17.1";
+const groundY = 64;
+const VANILLA_AIR_DROP_VEL_Y = (0 - 0.08) * Math.fround(0.98);
+
+describe("Horse settings resolution", () => {
+  it("normalizes float32 horse-specific fields only", () => {
+    const { FLOAT32_FIELDS, resolveHorseSettings } = loadHorseSettingsModule();
+    const horseSection = loadHorseSettingsJson().horses;
+    const defaultSettings = horseSection.default;
+    const { mcData } = loadMcData("1.17.1");
+    const resolved = resolveHorseSettings(mcData);
+
+    for (const field of FLOAT32_FIELDS) {
+      expect(resolved[field]).toBe(Math.fround(defaultSettings[field]));
+    }
+
+    expect(resolved.gravity).toBe(defaultSettings.gravity);
+    expect(resolved.defaultJumpStrength).toBe(defaultSettings.defaultJumpStrength);
+    expect(resolved.defaultJumpStrength).toBe(0.7);
+    expect(resolved.verticalDrag).toBe(Math.fround(defaultSettings.verticalDrag));
+    expect(resolved.waterInertia).toBe(Math.fround(defaultSettings.waterInertia));
+    expect(resolved.lavaShallowThreshold).toBe(defaultSettings.lavaShallowThreshold);
+  });
+
+  it("returns default settings for an unknown major version", () => {
+    const { FLOAT32_FIELDS, resolveHorseSettingsFromSection } = loadHorseSettingsModule();
+    const defaultSettings = loadHorseSettingsJson().horses.default;
+    const { mcData } = loadMcData("1.17.1");
+    const fakeMcData = {
+      ...mcData,
+      version: { ...mcData.version, majorVersion: "99.99" },
+    };
+    const resolved = resolveHorseSettingsFromSection(fakeMcData, loadHorseSettingsJson().horses);
+
+    for (const field of FLOAT32_FIELDS) {
+      expect(resolved[field]).toBe(Math.fround(defaultSettings[field]));
+    }
+  });
+
+  it("applies version-specific overrides and normalizes overridden float32 values", () => {
+    const { resolveHorseSettingsFromSection } = loadHorseSettingsModule();
+    const horseSection = loadHorseSettingsJson().horses;
+    const { mcData } = loadMcData("1.17.1");
+    const testSection = {
+      ...horseSection,
+      overrides: [{ versions: ["1.17"], values: { gravity: 0.05 } }],
+    };
+
+    const onTarget = resolveHorseSettingsFromSection(mcData, testSection);
+    expect(onTarget.gravity).toBe(0.05);
+
+    const offTarget = resolveHorseSettingsFromSection(
+      { ...mcData, version: { ...mcData.version, majorVersion: "1.15" } },
+      testSection,
+    );
+    expect(offTarget.gravity).toBe(horseSection.default.gravity);
+  });
+
+  it("lets the last matching override win when multiple entries match", () => {
+    const { resolveHorseSettingsFromSection } = loadHorseSettingsModule();
+    const horseSection = loadHorseSettingsJson().horses;
+    const { mcData } = loadMcData("1.17.1");
+    const testSection = {
+      ...horseSection,
+      overrides: [
+        { versions: ["1.17"], values: { defaultMovementSpeed: 0.1 } },
+        { versions: ["1.17"], values: { defaultMovementSpeed: 0.2 } },
+      ],
+    };
+
+    const resolved = resolveHorseSettingsFromSection(mcData, testSection);
+    expect(resolved.defaultMovementSpeed).toBe(Math.fround(0.2));
+  });
+});
+
+describe("Horse dimensions resolution", () => {
+  it("resolves donkey height separately from horse", () => {
+    const { resolveHorseDimensions } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const horseDims = resolveHorseDimensions(mcData, "horse");
+    const donkeyDims = resolveHorseDimensions(mcData, "donkey");
+    expect(horseDims.height).toBe(1.6);
+    expect(donkeyDims.height).toBe(1.5);
+  });
+
+  it("uses runtime entity dimensions when finite and positive", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+      entityName: "donkey",
+    });
+    expect(rig.horseState.height).toBe(1.5);
+    expect(rig.horseState.halfWidth * 2).toBeCloseTo(1.3964844, 5);
+  });
+
+  it("falls back when runtime dimensions are NaN or non-positive", () => {
+    const { pickRuntimeDimension, resolveHorseDimensions } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const dims = resolveHorseDimensions(mcData, "horse");
+
+    expect(pickRuntimeDimension(Number.NaN, dims.height)).toBe(dims.height);
+    expect(pickRuntimeDimension(0, dims.height)).toBe(dims.height);
+    expect(pickRuntimeDimension(-1, dims.width)).toBe(dims.width);
+    expect(pickRuntimeDimension(undefined, dims.height)).toBe(dims.height);
+
+    const state = HorseState.CREATE_FROM_ENTITY({ data: mcData } as any, {
+      position: new Vec3(0, groundY, 0),
+      velocity: new Vec3(0, 0, 0),
+      height: Number.NaN,
+      width: 0,
+      yaw: 0,
+      pitch: 0,
+      name: "horse",
+    } as any);
+    expect(state.height).toBe(dims.height);
+    expect(state.halfWidth * 2).toBe(dims.width);
+  });
+});
+
+describe("Horse attribute extractors", () => {
+  it("reads non-default movement speed far from fallback", () => {
+    const { getHorseMovementSpeedAttribute } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const speed = getHorseMovementSpeedAttribute(
+      { "generic.movement_speed": { value: 0.99, modifiers: [] } },
+      mcData,
+    );
+    expect(speed).toBeCloseTo(0.99, 5);
+  });
+
+  it("reads non-default jump strength far from fallback", () => {
+    const { getHorseJumpStrengthAttribute } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    const jump = getHorseJumpStrengthAttribute(
+      { "horse.jump_strength": { value: 0.15, modifiers: [] } },
+      mcData,
+    );
+    expect(jump).toBeCloseTo(0.15, 5);
+  });
+
+  it("uses vanilla defaults before attributes arrive", () => {
+    const state = HorseState.CREATE_FROM_ENTITY({ data: loadMcData("1.17.1").mcData } as any, {
+      position: new Vec3(0, 64, 0),
+      velocity: new Vec3(0, 0, 0),
+      height: 1.6,
+      width: 1.3964844,
+      yaw: 0,
+      pitch: 0,
+    } as any);
+    expect(state.movementSpeed).toBeCloseTo(0.225, 5);
+    expect(state.jumpStrength).toBe(0.7);
+  });
+
+  it("keeps defaultJumpStrength as double 0.7 on 1.17.1 fallback", () => {
+    const { getHorseJumpStrengthAttribute } = loadHorseSettingsModule();
+    const { mcData } = loadMcData("1.17.1");
+    expect(getHorseJumpStrengthAttribute({}, mcData)).toBe(0.7);
+  });
+});
+
+describe("Horse collision BB", () => {
+  it("uses getEntityBB dimensions for horse collision path", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    const bb = rig.physics.getEntityBB(rig.horseCtx, rig.horseState.pos);
+    expect(bb.maxY - bb.minY).toBeCloseTo(1.6, 3);
+    expect(bb.maxX - bb.minX).toBeCloseTo(1.3964844, 4);
+  });
+
+  it("uses donkey height in collision BB", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+      entityName: "donkey",
+    });
+    const bb = rig.physics.getEntityBB(rig.horseCtx, rig.horseState.pos);
+    expect(bb.maxY - bb.minY).toBeCloseTo(1.5, 3);
+  });
+});
+
+describe("Horse settings simulation parity", () => {
+  it("isolates resolved settings between rigs", () => {
+    const horseSection = loadHorseSettingsJson().horses;
+    const originalGravity = horseSection.default.gravity;
+    const rigA = createHorseRig({ version, position: new Vec3(0, groundY, 0), floorY: groundY - 1 });
+    const rigB = createHorseRig({ version, position: new Vec3(0, groundY, 0), floorY: groundY - 1 });
+
+    rigA.horseCtx.gravity = 999;
+    expect(rigB.horseCtx.gravity).not.toBe(999);
+    expect(horseSection.default.gravity).toBe(originalGravity);
+  });
+
+  it("matches exact first ground tick on stone", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    simulateHorseTick(rig);
+    expect(rig.horseState.pos.x).toBe(0);
+    expect(rig.horseState.pos.y).toBe(groundY);
+    expect(rig.horseState.pos.z).toBe(0);
+    expect(rig.horseState.vel.x).toBe(0);
+    expect(rig.horseState.vel.y).toBe(VANILLA_AIR_DROP_VEL_Y);
+    expect(rig.horseState.vel.z).toBe(0);
+  });
+
+  it("matches exact first forward ground tick on stone", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    rig.horseState.control.forward = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeCloseTo(-0.22049999309579482, 10);
+    expect(rig.horseState.vel.z).toBeCloseTo(-0.12039300448399745, 10);
+    expect(rig.horseState.vel.y).toBe(VANILLA_AIR_DROP_VEL_Y);
+  });
+
+  it("matches exact first forward ground tick on ice", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    for (let x = -1; x <= 1; x++) {
+      for (let z = -1; z <= 1; z++) {
+        rig.world.setIce(new Vec3(x, groundY - 1, z));
+      }
+    }
+    rig.horseState.control.forward = true;
+    simulateHorseTick(rig);
+    expect(rig.horseState.pos.z).toBeCloseTo(-0.05060391652869689, 12);
+    expect(rig.horseState.vel.z).toBeCloseTo(-0.045128574939215405, 12);
+    expect(rig.horseState.vel.y).toBe(VANILLA_AIR_DROP_VEL_Y);
+  });
+});

--- a/tests/unit/horse/state.test.ts
+++ b/tests/unit/horse/state.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import type { Entity } from "prismarine-entity";
+import { createHorseRig } from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const groundY = 64;
+
+describe("HorseState entity sync", () => {
+  it("applyToEntity keeps headYaw aligned with yaw", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    rig.horseState.updateControls(rig.horseState.control, Math.PI / 3, -Math.PI / 8);
+
+    const entity = {
+      position: new Vec3(0, groundY, 0),
+      velocity: new Vec3(0, 0, 0),
+      yaw: 0,
+      pitch: 0,
+      headYaw: 0,
+      onGround: true,
+    } as Entity & { headYaw: number };
+
+    rig.horseState.applyToEntity(entity);
+
+    expect(entity.yaw).toBeCloseTo(Math.PI / 3, 5);
+    expect(entity.pitch).toBeCloseTo(-Math.PI / 16, 5);
+    expect(entity.headYaw).toBeCloseTo(Math.PI / 3, 5);
+  });
+});

--- a/tests/unit/horse/world.test.ts
+++ b/tests/unit/horse/world.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "mocha";
+import expect from "expect";
+import { Vec3 } from "vec3";
+import {
+  createHorseRig,
+  simulateHorseTick,
+} from "../../helpers/unit/botcraftTestSupport";
+
+const version = "1.17.1";
+const groundY = 64;
+
+describe("HorsePhysics world readiness", () => {
+  it("pauses simulation when required blocks are missing", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    const loadedWorld = rig.world;
+    const worldWithHoles = {
+      getBlock(pos: Vec3) {
+        if (Math.abs(pos.x) > 1 || Math.abs(pos.z) > 1) return null;
+        return loadedWorld.getBlock(pos);
+      },
+    };
+    const before = rig.horseState.pos.clone();
+    rig.horseState.control.forward = true;
+    rig.physics.simulate(rig.horseCtx, worldWithHoles);
+    expect(rig.horseState.worldReady).toBe(false);
+    expect(rig.horseState.pos.equals(before)).toBe(true);
+  });
+
+  it("rebaseFromEntity updates position without mutating jump charge", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    rig.horseState.jumpChargeScale = 0.5;
+    rig.horseState.rebaseFromEntity({
+      position: new Vec3(5, groundY, 5),
+      velocity: new Vec3(0, 0, 0),
+      yaw: 1,
+      pitch: 0.5,
+      onGround: true,
+      height: 1.6,
+      width: 1.3964844,
+    } as any);
+    expect(rig.horseState.pos.x).toBe(5);
+    expect(rig.horseState.jumpChargeScale).toBeCloseTo(0.5, 5);
+  });
+
+  it("keeps finite state after simulation", () => {
+    const rig = createHorseRig({
+      version,
+      position: new Vec3(0, groundY, 0),
+      floorY: groundY - 1,
+    });
+    rig.horseState.control.forward = true;
+    for (let i = 0; i < 10; i++) simulateHorseTick(rig);
+    expect(
+      [
+        rig.horseState.pos.x,
+        rig.horseState.pos.y,
+        rig.horseState.pos.z,
+        rig.horseState.vel.x,
+        rig.horseState.vel.y,
+        rig.horseState.vel.z,
+        rig.horseState.yaw,
+        rig.horseState.pitch,
+      ].every(Number.isFinite),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
This is the horse follow-up I promised in #57. It is branched on the current
`upstream/master` (`05504e3`, i.e. after the boat merge) and contains no boat
code. Same approach as the boat PR: per-version vanilla files rather than one
representative version, an explicit statement of what is and is not covered, and
an automated matrix that fails loudly when a requested entity descriptor is
missing.

Three commits:

- `267c766` — a pure structural refactor: `IEntityState`, `Heading` and `getPose`
  move out of `states/index.ts` into `states/iEntityState.ts` and
  `states/entityPose.ts`, and `entityState` / `playerState` / `physicsUtils`
  import from direct paths instead of the barrel. `states/index.ts` previously
  imported from `../states` and from `../engines`, so adding a state that needs
  an engine type closed a cycle. Public exports through `states/index.ts` are
  unchanged apart from that split.
- `2aedff7` — the horse physics itself.
- `28685e8` — diagonal input normalization and skeleton-horse horizontal water
  slowdown.

## Version scope and data coverage

The implementation follows the vanilla ridden-horse model (`AbstractHorse` +
`LivingEntity.travel`) as it stands from 1.14.4 onward; nothing older is claimed. The automated matrix uses
`minecraft-data@3.111.0` and covers:

| version | entities asserted | block-below era | jump-power precision | wire attribute key |
|---|---|---|---|---|
| 1.14.4  | `horse`, `donkey`                          | full-block `minY - 1.0`  | double | `horse.jumpStrength` (raw string) |
| 1.16.5  | `horse`, `mule`                            | `minY - 0.5000001`       | double | `horse.jump_strength` (raw string) |
| 1.17.1  | `horse`, `skeleton_horse`, `zombie_horse`  | `minY - 0.5000001`       | double | `horse.jump_strength` (raw string) |
| 1.20.1  | `horse`, `donkey`                          | `getOnPos(0.500001F)`    | double | `horse.jump_strength` (`name` field) |
| 1.21.1  | `horse`                                    | `getOnPos(0.500001F)`    | float32 | `generic.jump_strength` (varint mapper) |
| 1.21.4  | `horse`, `donkey`                          | `getOnPos(0.500001F)`    | float32 | `generic.jump_strength` (varint mapper) |
| 1.21.11 | `horse`, `donkey`                          | `getOnPos(0.500001F)`    | float32 | `generic.jump_strength` (varint mapper) |

The five rideable `AbstractHorse` species (`horse`, `skeleton_horse`,
`zombie_horse`, `donkey`, `mule`) share one implementation because none of
`Horse`, `SkeletonHorse`, `ZombieHorse`, `AbstractChestedHorse`, `Donkey` or
`Mule` override `getRiddenInput`, `getRiddenSpeed`, `executeRidersJump`,
`tickRidden` or `travel`. Their movement-relevant differences are base attribute
values, dimensions, and one species override: `SkeletonHorse#getWaterSlowDown`
returns `0.96F` for horizontal water drag only (Y still uses the literal
`0.8F`). Attribute values and dimensions are read from runtime entity data; the
species-specific water behavior is selected from `HorseState.species` through
the settings table. Llamas are excluded because they are not saddle-controllable,
and camels are excluded because `Camel` has its own dash/sit movement and lives
outside the `horse` package.

Every matrix entry resolves the requested real entity descriptor and asserts the
simulated `height`/`halfWidth` against it, so nothing is pinned to the 1.17.1
horse size (`donkey` is `1.3964844 x 1.5` where `horse` is `1.3964844 x 1.6`).

`EPhysicsCtx` needed no classification change for horses: a horse resolves
through the existing living-entity path, and `HorsePhysics.applyHorseTravelContext`
rewrites the travel context every tick anyway. The matrix asserts that context
per version (`stepHeight` 1.0, `gravity` 0.08, `useControls` false,
`collisionBehavior { blockEffects: true, affectedAfterCollision: true }`).

## What is version-stable, and how it was checked

`entity_physics.json` has a `horses` section with an empty `overrides` array. That
is a claim, so here is what backs it. Each of these was read at the 1.14.4,
1.16.5, 1.17.1, 1.20.1, 1.21.1, 1.21.4 and 1.21.8 tags and is identical in all of
them:

```text
default MOVEMENT_SPEED (AbstractHorse) 0.225F
default JUMP_STRENGTH  (AbstractHorse) 0.7
ridden step height                     1.0
sideways input factor                  0.5F
backwards input factor                 0.25F
LivingEntity input damping             0.98F
forward jump impulse                   0.4F
gravity                                0.08
air Y drag                             0.98F
ground/air horizontal inertia          0.91F
friction-influenced speed numerator    0.21600002F
default block friction                 0.6F
water inertia (LivingEntity base)      0.8F (Y and shallow-lava Y)
water horizontal slowdown (horse)      0.8F
water horizontal slowdown (skeleton)   0.96F
liquid input acceleration              0.02F
lava horizontal/deep scale             0.5
lava shallow threshold                 0.4
airborne acceleration factor           0.1F
honey block jump factor                0.5F
out-of-liquid impulse                  0.3F
```

Representative sources for the shared model:

- ridden branch, pre-refactor:
  [1.17.1 `AbstractHorse#travel`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L690-L748)
  and
  [1.14.4 `AbstractHorse#travel`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.14.4/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L670-L743);
- ridden branch, post-refactor:
  [1.21.1 `AbstractHorse#getRiddenInput`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L785-L797),
  [`#getRiddenSpeed`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L800-L802),
  [`#executeRidersJump`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L804-L815),
  reached through
  [`LivingEntity#travelRidden`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L2195-L2206);
- ordinary movement:
  [1.17.1 `LivingEntity#travel`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L1980-L2116)
  and, after the 1.21.4 split,
  [`LivingEntity#travelInAir`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.4/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L2178-L2201)
  /
  [`#travelInFluid`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.4/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L2203-L2253);
- 1.21.11, which is past the last tag on the mirror above:
  [`AbstractHorse.java`](https://mcsrc.dev/1/1.21.11/net/minecraft/world/entity/animal/horse/AbstractHorse.java)
  and
  [`LivingEntity.java`](https://mcsrc.dev/1/1.21.11/net/minecraft/world/entity/LivingEntity.java)
  (no stable line anchors on that viewer, so the methods are named rather than
  linked by line).

The 1.21.4 refactor into `travelInAir`/`travelInFluid` reads as a restructure, not
a behavior change: `travelInAir` computes `float f = onGround() ? friction : 1.0F;
float g = f * 0.91F`, which is the same value as the older
`this.onGround ? p * 0.91F : 0.91F`. I am not presenting that as a version-specific
physics change, and `HorsePhysics` uses the 1.21.4 spelling (friction `1.0` when
airborne) because it is equivalent in both eras.

## Actual version boundaries found

### 1. Block below the feet — three eras

This decides which block's friction and jump factor apply, so it is load-bearing
for both movement and jump height.

- **≤1.14:** inlined in the air branch, a full-block step down —
  `new BlockPos(this.x, this.getBoundingBox().minY - 1.0, this.z)`
  ([1.14.4 `LivingEntity#travel`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.14.4/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L1821)).
- **1.15–1.19:** `Entity#getBlockPosBelowThatAffectsMyMovement` returns
  `minY - 0.5000001`
  ([1.17.1](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/Entity.java#L710-L712),
  still the same in
  [1.19.4](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.19.4/minecraft/src/net/minecraft/world/entity/Entity.java#L761-L763)).
- **1.20+:** it delegates to `getOnPos(0.500001F)`, which prefers
  `mainSupportingBlockPos`
  ([1.20.1](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.20.1/minecraft/src/net/minecraft/world/entity/Entity.java#L799-L816),
  [1.21.4](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.4/minecraft/src/net/minecraft/world/entity/Entity.java#L849-L866)):

  ```java
  BlockState blockState = this.level().getBlockState(blockPos);
  return (!(f <= 0.5) || !blockState.is(BlockTags.FENCES)) && !blockState.is(BlockTags.WALLS) && !(blockState.getBlock() instanceof FenceGateBlock)
      ? blockPos.atY(Mth.floor(this.position.y - f))
      : blockPos;
  ```

`horseBlockSupport.ts` models all three. Two details that are easy to get wrong
and are covered by tests:

- the offset is a `float` literal, so the comparison is against
  `Math.fround(0.500001) === 0.5000010132789612`, not `0.500001`. At
  `pos.y = 64.500001` vanilla floors to `63`, not `64`; that exact case is a test.
- `f = 0.500001F` is *not* `<= 0.5`, so the `FENCES` arm never fires at this call
  site and fences still get the recomputed Y. Walls and fence gates do keep the
  raw supporting position. All three are separate tests.

The 1.14.4-vs-1.16.5 difference is asserted behaviorally, not just structurally:
with farmland on top of ice, the two eras select different blocks and therefore
different friction.

### 2. Jump power — double chain until 1.20.x, full float32 from 1.21

Through 1.20.x the horse computes the jump in `double`:

[1.20.1 `AbstractHorse#executeRidersJump`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.20.1/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L791-L803)

```java
double d = this.getCustomJump() * f * this.getBlockJumpFactor();
double e = d + this.getJumpBoostPower();
```

From 1.21 it goes through `LivingEntity#getJumpPower(float)`, which is `float`
end to end:

[1.21.1 `LivingEntity#getJumpPower`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L2020-L2026)

```java
protected float getJumpPower(float f) {
    return (float)this.getAttributeValue(Attributes.JUMP_STRENGTH) * f * this.getBlockJumpFactor() + this.getJumpBoostPower();
}
```

`computeHorseJumpPower` branches on that. For `jumpStrength = 0.7`,
`scale = 0.4`, no jump boost:

```text
1.17.1 (double chain)   0.27999999999999997
1.21.1 (float32 chain)  0.2800000011920929
```

Both are asserted, and both are asserted again end-to-end as the post-tick
`vel.y === (jumpPower - 0.08) * Math.fround(0.98)`. The jump-strength attribute
read is frounded only on 1.21+, matching the `(float)` cast being on the read
site there and absent earlier.

### 3. Attribute keys — four different on-wire spellings

The registry name and the packet encoding both moved, and they did not move
together. Vanilla registry:

- [1.16.5 `Attributes`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.16.5/minecraft/src/net/minecraft/world/entity/ai/attributes/Attributes.java#L34-L36) — `horse.jump_strength`
  (1.14.4 predates that class and registers `horse.jumpStrength` directly on
  [`AbstractHorse`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.14.4/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L73));
- [1.21.1](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.1/minecraft/src/net/minecraft/world/entity/ai/attributes/Attributes.java#L51-L53) — `generic.jump_strength`, now a generic attribute;
- [1.21.4](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.21.4/minecraft/src/net/minecraft/world/entity/ai/attributes/Attributes.java#L44-L46) — `jump_strength`, prefix dropped.

What actually arrives in `entity.attributes` is a different question, and this is
the part worth flagging. Mineflayer stores `prop.key ?? prop.name`, and in
`minecraft-data@3.111.0` `entity_update_attributes` is:

```text
1.14.4 / 1.16.5   properties[].key   : string       -> "horse.jumpStrength" / "horse.jump_strength"
1.20.1            properties[].name  : string       -> "horse.jump_strength"
1.21.1+           properties[].key   : varint mapper -> "generic.jump_strength"
```

So on 1.21.4 and 1.21.11 `mcData.attributesByName.jumpStrength.resource` is
`minecraft:jump_strength`, but the value that reaches `entity.attributes` is
still `generic.jump_strength`, because the protocol mapper in this
`minecraft-data` release kept the old spelling. Resolving only through
`attributesByName` would silently miss the attribute there and fall back to the
`0.7` default, which is exactly the kind of failure that looks like working
physics. `lookupAttribute` therefore tries the `minecraft-data` resource names
first and then a fixed alias list, and the matrix feeds each version the key that
version's protocol actually produces.

## Jump charge and precision model

The rider-side charge is client state, so it is modelled from `LocalPlayer`
([1.17.1](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/client/player/LocalPlayer.java#L782-L808)):

```java
playerRideableJumping.onPlayerJump(Mth.floor(this.getJumpRidingScale() * 100.0F));
...
this.jumpRidingScale = this.jumpRidingTicks < 10
    ? this.jumpRidingTicks * 0.1F
    : 0.8F + 2.0F / (this.jumpRidingTicks - 9) * 0.1F;
```

and the horse side from
[`AbstractHorse#onPlayerJump`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/animal/horse/AbstractHorse.java#L843-L858):
`playerJumpPendingScale = 0.4F + 0.4F * i / 90.0F`, clamped to `1.0F` at `i >= 90`.

These are evaluated as a sequence of `float` operations rather than as a
double-precision expression, because the two differ. For charge index 8:

```text
sequential float32   0.4355555772781372   (matches vanilla)
naive fround(0.4 + 0.4 * (8 / 90))        (differs)
```

The same applies to `computeChargeScale(2) === 0.20000000298023224` and
`computeJumpBoostPower(2) === 0.20000000298023224`. `horseSettings.ts` carries a
table mapping every JSON field to its Java type and to where `Math.fround` is
applied, and `FLOAT32_FIELDS` normalizes the `float` literals once at resolve
time. Values that are `double` in vanilla (`gravity`, the `0.7` jump-strength
default, the `0.4` lava threshold, and all `Vec3` results) are deliberately not
frounded.

`getBlockJumpFactor` (honey blocks, `jumpFactor(0.5F)`) enters the chain from
1.15; the 1.14.4 horse jump has no such term. That falls out for free rather than
being special-cased, since `minecraft-data("1.14.4")` has no `honey_block` and the
factor stays `1.0`.

One regression this guards against: `executeRidersJump` assigns `deltaMovement.y`
directly, it does not take a maximum with the current velocity. A test sets
`vel.y = 1.2` before the jump and asserts the result is the vanilla value, i.e.
that the jump *reduces* upward velocity in that case.

## Travel branches

`HorsePhysics` implements the three `LivingEntity.travel` branches directly
instead of routing through the generic living path, so each keeps vanilla's own
ordering.

**Air** — `moveRelative` with `getFrictionInfluencedSpeed`, then `move`, then
gravity, then the `0.98F` Y drag, then horizontal friction
([1.17.1 `#handleRelativeFrictionAndCalculateMovement`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L2132-L2143),
[`#getFrictionInfluencedSpeed`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L2177-L2179)):

```text
accel      = onGround ? speed * (0.21600002F / friction^3) : speed * 0.1F
horizontal = (onGround ? friction : 1.0) * 0.91F
vel.y      = (vel.y - 0.08) * 0.98F
```

The `0.1F` airborne factor is the ridden `flyingSpeed`: pre-1.20 `AbstractHorse`
sets `this.flyingSpeed = this.getSpeed() * 0.1F` before delegating, and 1.20+
`LivingEntity#getFlyingSpeed` returns `getSpeed() * 0.1F` when the controlling
passenger is a player. Same value, different plumbing.

Input reaching the horse is already damped by `LivingEntity`'s `INPUT_FRICTION`
(`this.xxa *= 0.98F; this.zza *= 0.98F`), so `getRiddenInput`'s `0.5F` sideways
and `0.25F` backwards factors land on `0.98`-scaled values: forward `0.98`,
strafe `0.49`, backward `-0.245`. Those are the constants in `getTravelInput()`,
and they match what the library already uses on the player path. `applyHorseHeading`
then routes through vanilla `Entity#getInputVector` semantics: normalize when
`strafe² + forward² > 1.0` (the forward+strafe case is `1.2005`), skip when
below `1e-7`, and apply acceleration in double arithmetic without extra
`Math.fround`.

**Water** — drag first, then the falling adjustment, matching
`vec32.multiply(f, 0.8F, f)` followed by `getFluidFallingAdjustedMovement`
([1.17.1](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/LivingEntity.java#L2145-L2158)),
which is `vel.y - gravity/16` at `gravity = 0.08`. Horses do not sprint, cannot
carry Depth Strider and do not get Dolphin's Grace. Horizontal water drag comes
from `LivingEntity#getWaterSlowDown()` (`0.8F` by default,
`0.96F` on skeleton horses — implemented via `speciesOverrides` on
`waterHorizontalSlowDown`, resolved from `HorseState.species`). Vertical water
drag and shallow-lava Y drag use a separate `liquidVerticalInertia` (`0.8F`) so
the skeleton override never leaks into Y or lava branches.

**Lava** — shallow and deep are separate, gated on
[`Entity#getFluidJumpThreshold`](https://code.chipmunk.land/dinhero21/MinecraftDeobfuscated-Mojang/src/tag/1.17.1/minecraft/src/net/minecraft/world/entity/Entity.java#L2833-L2835)
(`0.4` for anything with eye height above `0.4`, which is every horse):

```text
fluidHeight <= 0.4 : vel = (vel.x * 0.5, vel.y * 0.8 - gravity/16, vel.z * 0.5)
fluidHeight >  0.4 : vel = vel * 0.5
then               : vel.y -= gravity / 4
```

Lava depth is derived from the block level with vanilla's
`deflate(0.001)` query box, and "in lava" is `fluidTop >= bb.minY`, so touching
the surface counts. Tests pin the boundary at `y ≈ 63.85` (detected) versus
`y = 63.9` (not detected) above a source block, cover a flowing-level block whose
`level` property arrives as a string, and cover the horizontal BB edge.

Both liquid branches end with the out-of-liquid impulse
(`horizontalCollision && isFree(x, 0.6 - y + lastY, z) -> vel.y = 0.3F`).

Water presence itself reuses the existing `EntityPhysics.isInWaterApplyCurrent`
helper and its `0.401` descending-BB convention, so horses agree with the rest of
the library rather than introducing a second answer to the same question. Lava is
scanned separately because the shallow/deep branch needs an actual fluid height,
which that helper does not return.

## Deliberately out of scope

Stated explicitly rather than left for a reviewer to find:

- **Lava flow pushing.** `updateFluidHeightAndDoFluidPushing` applies a horizontal
  push from flowing lava. Only the height is read here; the push is not applied.
  Water current *is* applied, via the existing helper.
- **Rearing.** `getRiddenInput` returns `Vec3.ZERO` while `isStanding() &&
  !allowStandSliding`. `HorseState` carries the flags but the gate is not
  implemented, because rearing is server-driven metadata that a bot does not
  trigger.
- **The saddle gate.** `travel` requires `isSaddled()`; that check stays in the
  consumer, same as the boat PR left mounting to the caller.
- **Slow Falling and Levitation** on the horse. The air branch uses a flat
  `0.08` gravity. Note that the `-0.003` clamp inside
  `getFluidFallingAdjustedMovement` is unreachable at `gravity = 0.08` — its two
  conditions are mutually exclusive there — so it is not a gap in the water
  branch, only under Slow Falling.
- **Baby dimensions.** `Horse#getDefaultDimensions` returns `BABY_DIMENSIONS`
  for foals; the simulation takes whatever `height`/`width` the runtime entity
  carries and falls back to the adult descriptor.

## Tests and local integration

154 horse tests across six files. Per version and entity the matrix asserts
descriptor resolution and dimensions, the living-entity travel context, attribute
reads through that version's real packet key, forward motion, and finite state
over 20 ticks. Beyond the matrix: the three block-below eras and the
fence/wall/fence-gate arms, the two jump-power precision chains, the float32
charge/pending/boost sequences, honey-block jump factor, the water and lava
oracles above, diagonal input normalization (forward-only unchanged,
forward+strafe unit-length acceleration, zero-input safety), skeleton-horse
horizontal water slowdown with separate vertical/lava inertia, backward-slower-than-forward,
symmetric strafing, ice-versus-stone, step-up over a one-block ledge, wall
collision, no sprint multiplier, rider yaw and half-pitch, `clone` independence
(including species), `rebaseFromEntity` not clobbering jump charge, and
simulation pausing when a required block is unloaded.

Several tests assert exact first-tick values rather than tolerances, e.g. forward on
stone at speed `0.225`:

```text
pos.z  -0.22049999309579482
vel.z  -0.12039300448399745
vel.y  (0 - 0.08) * Math.fround(0.98)
```

Local results, Node 20.20.0:

```text
npm run build
PASS

TS_NODE_TRANSPILE_ONLY=true npx mocha --require ts-node/register "tests/unit/horse/**/*.test.ts"
154 passing, 0 failing

TS_NODE_TRANSPILE_ONLY=true npm test  (this branch)
445 passing, 36 pending, 5 failing

TS_NODE_TRANSPILE_ONLY=true npm test  (upstream/master 05504e3)
291 passing, 36 pending, 5 failing
```

`npm run build` performs the full TypeScript type-check. `TS_NODE_TRANSPILE_ONLY`
is used only for the Mocha runs to avoid the current ts-node/Mocha `src`/`dist`
loader conflict.

The five failures are identical on both sides — the pre-existing Botcraft
dry-sign water-channel tests for 1.18.2 and 1.21.11 plus `captured AFK-client
spawn`. This branch adds 154 passing horse tests and no new failure.

No Mineflayer version gate is widened by this library PR. Wiring horse control
into Mineflayer (the `steer_vehicle` / `player_input` packet spread and the
per-version entity names) stays a separate integration task.
